### PR TITLE
feat: add segregation of duties schema, types, and spec

### DIFF
--- a/spec/schemas/agent-yaml.schema.json
+++ b/spec/schemas/agent-yaml.schema.json
@@ -429,6 +429,9 @@
         },
         "vendor_management": {
           "$ref": "#/$defs/vendor_management_config"
+        },
+        "segregation_of_duties": {
+          "$ref": "#/$defs/segregation_of_duties_config"
         }
       },
       "additionalProperties": false,
@@ -659,6 +662,116 @@
         "subcontractor_assessment": {
           "type": "boolean",
           "description": "Whether fourth-party (subcontractor) risk has been assessed"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "segregation_of_duties_config": {
+      "type": "object",
+      "description": "Segregation of duties configuration for multi-agent systems. Ensures no single agent has complete control over critical processes.",
+      "properties": {
+        "roles": {
+          "type": "array",
+          "description": "Roles that agents can hold in this system",
+          "items": {
+            "type": "object",
+            "required": ["id", "description"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_]*$",
+                "description": "Role identifier (snake_case)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Human-readable role description"
+              },
+              "permissions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["create", "submit", "review", "approve", "reject", "execute", "audit", "report"]
+                },
+                "uniqueItems": true,
+                "description": "Permissions granted to this role"
+              }
+            },
+            "additionalProperties": false
+          },
+          "minItems": 2
+        },
+        "conflicts": {
+          "type": "array",
+          "description": "Pairs of role IDs that cannot be held by the same agent (SOD matrix)",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "assignments": {
+          "type": "object",
+          "description": "Maps agent names to their assigned roles",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          }
+        },
+        "isolation": {
+          "type": "object",
+          "description": "Isolation level between agents with different roles",
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": ["full", "shared", "none"],
+              "description": "'full': agents cannot access each other's state. 'shared': read-only cross-access. 'none': no isolation."
+            },
+            "credentials": {
+              "type": "string",
+              "enum": ["separate", "shared"],
+              "description": "'separate': each role has its own credential scope. 'shared': agents share credentials."
+            }
+          },
+          "additionalProperties": false
+        },
+        "handoffs": {
+          "type": "array",
+          "description": "Critical actions requiring multi-role participation",
+          "items": {
+            "type": "object",
+            "required": ["action", "required_roles"],
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Action type requiring handoff (e.g., credit_decision, loan_disbursement)"
+              },
+              "required_roles": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 2,
+                "description": "Roles that must participate sequentially"
+              },
+              "approval_required": {
+                "type": "boolean",
+                "description": "Whether explicit approval is needed at each handoff",
+                "default": true
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "enforcement": {
+          "type": "string",
+          "enum": ["strict", "advisory"],
+          "description": "'strict': SOD violations are errors. 'advisory': SOD violations are warnings.",
+          "default": "strict"
         }
       },
       "additionalProperties": false

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -115,6 +115,25 @@ export interface ComplianceConfig {
     vendor_ai_notification?: boolean;
     subcontractor_assessment?: boolean;
   };
+  segregation_of_duties?: {
+    roles?: Array<{
+      id: string;
+      description: string;
+      permissions?: string[];
+    }>;
+    conflicts?: Array<[string, string]>;
+    assignments?: Record<string, string[]>;
+    isolation?: {
+      state?: string;
+      credentials?: string;
+    };
+    handoffs?: Array<{
+      action: string;
+      required_roles: string[];
+      approval_required?: boolean;
+    }>;
+    enforcement?: string;
+  };
 }
 
 export function loadAgentManifest(dir: string): AgentManifest {


### PR DESCRIPTION
## Summary

Adds the `segregation_of_duties` subsection to the gitagent compliance schema — a new spec-level concept for enforcing that no single agent controls a critical process end-to-end.

- **JSON Schema** (`agent-yaml.schema.json`): Full `segregation_of_duties_config` definition with roles (id, description, permissions), conflicts (2-tuples), assignments (agent→roles mapping), isolation (state/credentials enums), handoffs (action + required_roles + approval), and enforcement (strict/advisory)
- **TypeScript types** (`loader.ts`): `segregation_of_duties` added to `ComplianceConfig` interface
- **Specification** (`SPECIFICATION.md`): DUTIES.md convention (root + per-agent levels), SOD YAML documentation, validation rule #8, regulatory reference table (FINOS, SOC 2, SR 11-7, FINRA 3110)

## Context

Inspired by Salient AI's purpose-built agent architecture (each agent scoped to one duty in the lending lifecycle) and the FINOS AI Governance Framework's multi-agent isolation controls.

Closes #10 (part 1 of 4)

## Test plan

- [x] `npm run build` passes cleanly
- [ ] Review schema validates correctly against example agents
- [ ] Spec documentation is clear and complete

## PR Stack

This is **PR 1 of 4** for the SOD feature:
1. **Spec + Schema + Types** (this PR)
2. CLI support (validate, audit, init)
3. Adapter support (system-prompt, claude-code)
4. Examples + docs (examples/full/, README)

🤖 Generated with [Claude Code](https://claude.ai/code)