### PR TITLE
feat: add SOD constraints to system-prompt and claude-code adapters

### DIFF
--- a/spec/schemas/agent-yaml.schema.json
+++ b/spec/schemas/agent-yaml.schema.json
@@ -429,6 +429,9 @@
         },
         "vendor_management": {
           "$ref": "#/$defs/vendor_management_config"
+        },
+        "segregation_of_duties": {
+          "$ref": "#/$defs/segregation_of_duties_config"
         }
       },
       "additionalProperties": false,
@@ -659,6 +662,116 @@
         "subcontractor_assessment": {
           "type": "boolean",
           "description": "Whether fourth-party (subcontractor) risk has been assessed"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "segregation_of_duties_config": {
+      "type": "object",
+      "description": "Segregation of duties configuration for multi-agent systems. Ensures no single agent has complete control over critical processes.",
+      "properties": {
+        "roles": {
+          "type": "array",
+          "description": "Roles that agents can hold in this system",
+          "items": {
+            "type": "object",
+            "required": ["id", "description"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_]*$",
+                "description": "Role identifier (snake_case)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Human-readable role description"
+              },
+              "permissions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["create", "submit", "review", "approve", "reject", "execute", "audit", "report"]
+                },
+                "uniqueItems": true,
+                "description": "Permissions granted to this role"
+              }
+            },
+            "additionalProperties": false
+          },
+          "minItems": 2
+        },
+        "conflicts": {
+          "type": "array",
+          "description": "Pairs of role IDs that cannot be held by the same agent (SOD matrix)",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "assignments": {
+          "type": "object",
+          "description": "Maps agent names to their assigned roles",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          }
+        },
+        "isolation": {
+          "type": "object",
+          "description": "Isolation level between agents with different roles",
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": ["full", "shared", "none"],
+              "description": "'full': agents cannot access each other's state. 'shared': read-only cross-access. 'none': no isolation."
+            },
+            "credentials": {
+              "type": "string",
+              "enum": ["separate", "shared"],
+              "description": "'separate': each role has its own credential scope. 'shared': agents share credentials."
+            }
+          },
+          "additionalProperties": false
+        },
+        "handoffs": {
+          "type": "array",
+          "description": "Critical actions requiring multi-role participation",
+          "items": {
+            "type": "object",
+            "required": ["action", "required_roles"],
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Action type requiring handoff (e.g., credit_decision, loan_disbursement)"
+              },
+              "required_roles": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 2,
+                "description": "Roles that must participate sequentially"
+              },
+              "approval_required": {
+                "type": "boolean",
+                "description": "Whether explicit approval is needed at each handoff",
+                "default": true
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "enforcement": {
+          "type": "string",
+          "enum": ["strict", "advisory"],
+          "description": "'strict': SOD violations are errors. 'advisory': SOD violations are warnings.",
+          "default": "strict"
         }
       },
       "additionalProperties": false

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -262,6 +262,36 @@ metadata:
 Describe the skill instructions here.
 `;
 
+const FULL_DUTIES_MD = `# Duties
+
+System-wide segregation of duties policy.
+
+## Roles
+
+| Role | Agent | Permissions | Description |
+|------|-------|-------------|-------------|
+| (define roles) | (assign agents) | (list permissions) | (describe duty) |
+
+## Conflict Matrix
+
+No single agent may hold both roles in any pair:
+
+- (define role conflicts)
+
+## Handoff Workflows
+
+(Define critical actions that require multi-role handoff)
+
+## Isolation Policy
+
+- **State isolation:** (full | shared | none)
+- **Credential segregation:** (separate | shared)
+
+## Enforcement
+
+(strict | advisory)
+`;
+
 const REGULATORY_MAP = `mappings: []
 `;
 
@@ -346,6 +376,7 @@ export const initCommand = new Command('init')
       createFile(join(dir, 'SOUL.md'), STANDARD_SOUL_MD);
       createFile(join(dir, 'RULES.md'), FULL_RULES_MD);
       createFile(join(dir, 'AGENTS.md'), AGENTS_MD);
+      createFile(join(dir, 'DUTIES.md'), FULL_DUTIES_MD);
 
       createDir(join(dir, 'skills', 'example-skill'));
       createFile(join(dir, 'skills', 'example-skill', 'SKILL.md'), SKILL_MD);
@@ -392,6 +423,7 @@ export const initCommand = new Command('init')
       success('Created SOUL.md');
       success('Created RULES.md');
       success('Created AGENTS.md');
+      success('Created DUTIES.md');
       success('Created skills/example-skill/SKILL.md');
       success('Created knowledge/index.yaml');
       success('Created memory/MEMORY.md + memory.yaml');

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -115,6 +115,25 @@ export interface ComplianceConfig {
     vendor_ai_notification?: boolean;
     subcontractor_assessment?: boolean;
   };
+  segregation_of_duties?: {
+    roles?: Array<{
+      id: string;
+      description: string;
+      permissions?: string[];
+    }>;
+    conflicts?: Array<[string, string]>;
+    assignments?: Record<string, string[]>;
+    isolation?: {
+      state?: string;
+      credentials?: string;
+    };
+    handoffs?: Array<{
+      action: string;
+      required_roles: string[];
+      approval_required?: boolean;
+    }>;
+    enforcement?: string;
+  };
 }
 
 export function loadAgentManifest(dir: string): AgentManifest {


### PR DESCRIPTION
## Summary

Adds segregation of duties output to both export adapters:

- **system-prompt.ts**: Exports SOD role assignments, conflict rules, handoff requirements, isolation constraints, and enforcement mode as natural language instructions. Also loads `DUTIES.md` content.
- **claude-code.ts**: Includes SOD subsection in the Compliance section of generated CLAUDE.md. Loads `DUTIES.md` alongside SOUL.md and RULES.md.

## Context

Part 3 of 4 for the SOD feature (#10). Depends on #12 (CLI commands).

## Test plan

- [x] `npm run build` passes cleanly
- [x] `node dist/index.js export --format system-prompt -d examples/full` — includes SOD constraints
- [x] `node dist/index.js export --format claude-code -d examples/full` — includes SOD section

## PR Stack

1. Spec + Schema + Types (#11)
2. CLI support (#12)
3. **Adapter support** (this PR)
4. Examples + docs

🤖 Generated with [Claude Code](https://claude.ai/code)