### PR TITLE
feat: add SOD examples, DUTIES.md files, and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ my-agent/
 │
 │   # ── Behavior & Rules ──────────────────────────────────
 ├── RULES.md                # Hard constraints, must-always/must-never, safety boundaries
-├── DUTIES.md                 # Segregation of duties policy and role boundaries
+├── DUTIES.md               # Segregation of duties policy and role boundaries
 ├── AGENTS.md               # Framework-agnostic fallback instructions
 │
 │   # ── Capabilities ──────────────────────────────────────
@@ -60,7 +60,7 @@ my-agent/
 │   └── fact-checker/
 │       ├── agent.yaml
 │       ├── SOUL.md
-│       └── DUTIES.md         # This agent's role, permissions, boundaries
+│       └── DUTIES.md       # This agent's role, permissions, boundaries
 ├── examples/               # Calibration interactions (few-shot)
 │
 │   # ── Runtime ───────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Every AI framework has its own structure. There's no universal, portable way to 
 
 - **Git-native** — Version control, branching, diffing, and collaboration built in
 - **Framework-agnostic** — Export to any framework with adapters
-- **Compliance-ready** — First-class support for FINRA, Federal Reserve, and SEC regulatory requirements
+- **Compliance-ready** — First-class support for FINRA, Federal Reserve, SEC, and segregation of duties
 - **Composable** — Agents can extend, depend on, and delegate to other agents
 
 ## The Standard
@@ -34,6 +34,7 @@ my-agent/
 │
 │   # ── Behavior & Rules ──────────────────────────────────
 ├── RULES.md                # Hard constraints, must-always/must-never, safety boundaries
+├── DUTIES.md                 # Segregation of duties policy and role boundaries
 ├── AGENTS.md               # Framework-agnostic fallback instructions
 │
 │   # ── Capabilities ──────────────────────────────────────
@@ -58,7 +59,8 @@ my-agent/
 ├── agents/                 # Sub-agent definitions (recursive structure)
 │   └── fact-checker/
 │       ├── agent.yaml
-│       └── SOUL.md
+│       ├── SOUL.md
+│       └── DUTIES.md         # This agent's role, permissions, boundaries
 ├── examples/               # Calibration interactions (few-shot)
 │
 │   # ── Runtime ───────────────────────────────────────────
@@ -75,6 +77,31 @@ These are the architectural patterns that emerge when you define agents as git-n
 When an agent learns a new skill or writes to memory, it opens a branch + PR for human review before merging.
 
 <img src="patterns/human-in-the-loop.png" alt="Human-in-the-Loop" width="600" />
+
+### Segregation of Duties (SOD)
+No single agent should control a critical process end-to-end. Define roles (`maker`, `checker`, `executor`, `auditor`), a conflict matrix (which roles can't be the same agent), and handoff workflows — all in `agent.yaml` + `DUTIES.md`. The validator catches violations before deployment.
+
+```yaml
+compliance:
+  segregation_of_duties:
+    roles:
+      - id: maker
+        description: Creates proposals
+        permissions: [create, submit]
+      - id: checker
+        description: Reviews and approves
+        permissions: [review, approve, reject]
+    conflicts:
+      - [maker, checker]         # maker cannot approve own work
+    assignments:
+      loan-originator: [maker]
+      credit-reviewer: [checker]
+    handoffs:
+      - action: credit_decision
+        required_roles: [maker, checker]
+        approval_required: true
+    enforcement: strict
+```
 
 ### Live Agent Memory
 The `memory/` folder holds a `runtime/` subfolder where agents write live knowledge — `dailylog.md`, `key-decisions.md`, and `context.md` — persisting state across sessions.
@@ -183,6 +210,18 @@ compliance:
   model_risk:
     validation_cadence: quarterly
     ongoing_monitoring: true
+  segregation_of_duties:
+    roles:
+      - id: analyst
+        permissions: [create, submit]
+      - id: reviewer
+        permissions: [review, approve, reject]
+    conflicts:
+      - [analyst, reviewer]
+    assignments:
+      compliance-analyst: [analyst]
+      fact-checker: [reviewer]
+    enforcement: strict
 ```
 
 ## CLI Commands
@@ -217,6 +256,16 @@ gitagent has first-class support for financial regulatory compliance:
 ### SEC / CFPB
 - **Reg S-P** — Customer privacy, PII handling
 - **CFPB Circular 2022-03** — Explainable adverse action, Less Discriminatory Alternative search
+
+### Segregation of Duties
+- **Roles & Permissions** — Define maker, checker, executor, auditor roles with controlled permissions
+- **Conflict Matrix** — Declare which role pairs cannot be held by the same agent
+- **Handoff Workflows** — Require multi-agent participation for critical actions (credit decisions, regulatory filings)
+- **Isolation** — Full state and credential segregation between roles
+- **DUTIES.md** — Root-level policy + per-agent role declarations
+- **Enforcement** — Strict (blocks deployment) or advisory (warnings only)
+
+Inspired by [Salient AI](https://www.trysalient.com/)'s purpose-built agent architecture and the [FINOS AI Governance Framework](https://air-governance-framework.finos.org/mitigations/mi-22_multi-agent-isolation-and-segmentation.html).
 
 Run `gitagent audit` for a full compliance checklist against your agent configuration.
 
@@ -264,7 +313,7 @@ See the `examples/` directory:
 
 - **`examples/minimal/`** — 2-file hello world (agent.yaml + SOUL.md)
 - **`examples/standard/`** — Code review agent with skills, tools, and rules
-- **`examples/full/`** — Production compliance agent with all directories, hooks, workflows, sub-agents, and regulatory artifacts
+- **`examples/full/`** — Production compliance agent with all directories, hooks, workflows, sub-agents, SOD with DUTIES.md, and regulatory artifacts
 - **`examples/gitagent-helper/`** — Helper agent that assists with creating gitagent definitions
 - **`examples/lyzr-agent/`** — Example Lyzr Studio integration
 

--- a/examples/full/DUTIES.md
+++ b/examples/full/DUTIES.md
@@ -1,0 +1,40 @@
+# Duties
+
+System-wide segregation of duties policy for the compliance-analyst agent system.
+
+## Roles
+
+| Role | Agent | Permissions | Description |
+|------|-------|-------------|-------------|
+| Analyst | compliance-analyst | create, submit | Performs regulatory analysis, generates findings and reports |
+| Reviewer | fact-checker | review, approve, reject | Reviews analysis for accuracy, verifies claims against authoritative sources |
+| Auditor | (unassigned) | audit, report | Audits completed reviews and maintains the compliance trail |
+
+## Conflict Matrix
+
+No single agent may hold both roles in any pair:
+
+- **Analyst <-> Reviewer** — The agent that produces findings cannot approve them
+- **Analyst <-> Auditor** — The agent that produces findings cannot audit them
+- **Reviewer <-> Auditor** — The agent that approves findings cannot audit the approval
+
+## Handoff Workflows
+
+### Regulatory Filing
+1. **Analyst** creates the filing draft and submits for review
+2. **Reviewer** verifies accuracy against authoritative sources, approves or rejects
+3. Approval required at each step before proceeding
+
+### Customer Communication
+1. **Analyst** drafts the communication
+2. **Reviewer** checks for FINRA 2210 compliance (fair, balanced, no misleading statements)
+3. Approval required before any communication is sent
+
+## Isolation Policy
+
+- **State isolation: full** — Each agent operates with its own memory and state. No agent may read or modify another agent's working memory.
+- **Credential segregation: separate** — Each role has its own credential scope. The analyst's data access credentials are distinct from the reviewer's.
+
+## Enforcement
+
+Enforcement mode is **strict**. Any SOD violation (e.g., assigning conflicting roles to the same agent) will fail validation and block deployment.

--- a/examples/full/agent.yaml
+++ b/examples/full/agent.yaml
@@ -96,6 +96,42 @@ compliance:
     soc_report_required: true
     vendor_ai_notification: true
     subcontractor_assessment: true
+  segregation_of_duties:
+    roles:
+      - id: analyst
+        description: Performs regulatory analysis and generates findings
+        permissions:
+          - create
+          - submit
+      - id: reviewer
+        description: Reviews analysis for accuracy and completeness
+        permissions:
+          - review
+          - approve
+          - reject
+      - id: auditor
+        description: Audits completed reviews and maintains compliance trail
+        permissions:
+          - audit
+          - report
+    conflicts:
+      - [analyst, reviewer]
+      - [analyst, auditor]
+      - [reviewer, auditor]
+    assignments:
+      compliance-analyst: [analyst]
+      fact-checker: [reviewer]
+    isolation:
+      state: full
+      credentials: separate
+    handoffs:
+      - action: regulatory_filing
+        required_roles: [analyst, reviewer]
+        approval_required: true
+      - action: customer_communication
+        required_roles: [analyst, reviewer]
+        approval_required: true
+    enforcement: strict
 tags:
   - compliance
   - financial-services

--- a/examples/full/agents/fact-checker/DUTIES.md
+++ b/examples/full/agents/fact-checker/DUTIES.md
@@ -1,0 +1,36 @@
+# Duties
+
+## Role
+
+**Reviewer** — Reviews analysis for accuracy and completeness.
+
+## Permissions
+
+- **review** — Examine outputs produced by the analyst
+- **approve** — Approve findings that meet accuracy and compliance standards
+- **reject** — Reject findings that are inaccurate, incomplete, or non-compliant
+
+## Boundaries
+
+### Must
+- Verify all factual claims against authoritative regulatory sources before approving
+- Reject any finding that cannot be independently verified
+- Document the basis for every approval or rejection decision
+
+### Must Not
+- Create original analysis or findings (analyst role only)
+- Modify the analyst's work — only approve or reject
+- Access the analyst's working state or memory
+- Use credentials assigned to other roles
+- Audit own review decisions (auditor role only)
+
+## Handoff Participation
+
+| Action | Position in Chain | Receives From | Hands Off To |
+|--------|------------------|---------------|--------------|
+| regulatory_filing | Step 2 | analyst | (terminal — approved or rejected) |
+| customer_communication | Step 2 | analyst | (terminal — approved or rejected) |
+
+## Isolation
+
+This agent operates under **full state isolation** with **separate credentials**. It cannot access the compliance-analyst's memory, state, or data access tokens.

--- a/examples/full/compliance/regulatory-map.yaml
+++ b/examples/full/compliance/regulatory-map.yaml
@@ -77,3 +77,26 @@ mappings:
         controls:
           - vendor_supervisory_procedures
           - vendor_ai_change_notification
+
+  - capability: duty_segregation
+    rules:
+      - id: finos-ai-governance
+        name: "FINOS AI Governance — Multi-Agent Isolation"
+        controls:
+          - role_definition
+          - conflict_matrix_enforcement
+          - assignment_validation
+          - state_isolation
+          - credential_segregation
+      - id: finra-3110-sod
+        name: "FINRA Rule 3110 — Supervisory Separation"
+        controls:
+          - maker_checker_separation
+          - approval_workflow_enforcement
+          - independent_review_requirement
+      - id: soc2-logical-access
+        name: "SOC 2 — Logical Access Controls"
+        controls:
+          - role_based_access_control
+          - credential_isolation
+          - cross_boundary_approval

--- a/spec/schemas/agent-yaml.schema.json
+++ b/spec/schemas/agent-yaml.schema.json
@@ -429,6 +429,9 @@
         },
         "vendor_management": {
           "$ref": "#/$defs/vendor_management_config"
+        },
+        "segregation_of_duties": {
+          "$ref": "#/$defs/segregation_of_duties_config"
         }
       },
       "additionalProperties": false,
@@ -659,6 +662,116 @@
         "subcontractor_assessment": {
           "type": "boolean",
           "description": "Whether fourth-party (subcontractor) risk has been assessed"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "segregation_of_duties_config": {
+      "type": "object",
+      "description": "Segregation of duties configuration for multi-agent systems. Ensures no single agent has complete control over critical processes.",
+      "properties": {
+        "roles": {
+          "type": "array",
+          "description": "Roles that agents can hold in this system",
+          "items": {
+            "type": "object",
+            "required": ["id", "description"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_]*$",
+                "description": "Role identifier (snake_case)"
+              },
+              "description": {
+                "type": "string",
+                "description": "Human-readable role description"
+              },
+              "permissions": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["create", "submit", "review", "approve", "reject", "execute", "audit", "report"]
+                },
+                "uniqueItems": true,
+                "description": "Permissions granted to this role"
+              }
+            },
+            "additionalProperties": false
+          },
+          "minItems": 2
+        },
+        "conflicts": {
+          "type": "array",
+          "description": "Pairs of role IDs that cannot be held by the same agent (SOD matrix)",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "assignments": {
+          "type": "object",
+          "description": "Maps agent names to their assigned roles",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          }
+        },
+        "isolation": {
+          "type": "object",
+          "description": "Isolation level between agents with different roles",
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": ["full", "shared", "none"],
+              "description": "'full': agents cannot access each other's state. 'shared': read-only cross-access. 'none': no isolation."
+            },
+            "credentials": {
+              "type": "string",
+              "enum": ["separate", "shared"],
+              "description": "'separate': each role has its own credential scope. 'shared': agents share credentials."
+            }
+          },
+          "additionalProperties": false
+        },
+        "handoffs": {
+          "type": "array",
+          "description": "Critical actions requiring multi-role participation",
+          "items": {
+            "type": "object",
+            "required": ["action", "required_roles"],
+            "properties": {
+              "action": {
+                "type": "string",
+                "description": "Action type requiring handoff (e.g., credit_decision, loan_disbursement)"
+              },
+              "required_roles": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 2,
+                "description": "Roles that must participate sequentially"
+              },
+              "approval_required": {
+                "type": "boolean",
+                "description": "Whether explicit approval is needed at each handoff",
+                "default": true
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "enforcement": {
+          "type": "string",
+          "enum": ["strict", "advisory"],
+          "description": "'strict': SOD violations are errors. 'advisory': SOD violations are warnings.",
+          "default": "strict"
         }
       },
       "additionalProperties": false

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -262,6 +262,36 @@ metadata:
 Describe the skill instructions here.
 `;
 
+const FULL_DUTIES_MD = `# Duties
+
+System-wide segregation of duties policy.
+
+## Roles
+
+| Role | Agent | Permissions | Description |
+|------|-------|-------------|-------------|
+| (define roles) | (assign agents) | (list permissions) | (describe duty) |
+
+## Conflict Matrix
+
+No single agent may hold both roles in any pair:
+
+- (define role conflicts)
+
+## Handoff Workflows
+
+(Define critical actions that require multi-role handoff)
+
+## Isolation Policy
+
+- **State isolation:** (full | shared | none)
+- **Credential segregation:** (separate | shared)
+
+## Enforcement
+
+(strict | advisory)
+`;
+
 const REGULATORY_MAP = `mappings: []
 `;
 
@@ -346,6 +376,7 @@ export const initCommand = new Command('init')
       createFile(join(dir, 'SOUL.md'), STANDARD_SOUL_MD);
       createFile(join(dir, 'RULES.md'), FULL_RULES_MD);
       createFile(join(dir, 'AGENTS.md'), AGENTS_MD);
+      createFile(join(dir, 'DUTIES.md'), FULL_DUTIES_MD);
 
       createDir(join(dir, 'skills', 'example-skill'));
       createFile(join(dir, 'skills', 'example-skill', 'SKILL.md'), SKILL_MD);
@@ -392,6 +423,7 @@ export const initCommand = new Command('init')
       success('Created SOUL.md');
       success('Created RULES.md');
       success('Created AGENTS.md');
+      success('Created DUTIES.md');
       success('Created skills/example-skill/SKILL.md');
       success('Created knowledge/index.yaml');
       success('Created memory/MEMORY.md + memory.yaml');

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -115,6 +115,25 @@ export interface ComplianceConfig {
     vendor_ai_notification?: boolean;
     subcontractor_assessment?: boolean;
   };
+  segregation_of_duties?: {
+    roles?: Array<{
+      id: string;
+      description: string;
+      permissions?: string[];
+    }>;
+    conflicts?: Array<[string, string]>;
+    assignments?: Record<string, string[]>;
+    isolation?: {
+      state?: string;
+      credentials?: string;
+    };
+    handoffs?: Array<{
+      action: string;
+      required_roles: string[];
+      approval_required?: boolean;
+    }>;
+    enforcement?: string;
+  };
 }
 
 export function loadAgentManifest(dir: string): AgentManifest {


### PR DESCRIPTION
## Summary

Adds examples, documentation, and DUTIES.md files for the segregation of duties feature:

- **examples/full/agent.yaml**: `segregation_of_duties` config with analyst, reviewer, and auditor roles, 3 conflict pairs, assignments, full isolation, 2 handoff workflows, strict enforcement
- **examples/full/DUTIES.md**: Root-level SOD policy — roles table, conflict matrix, handoff workflows (regulatory filing, customer communication), isolation policy, enforcement mode
- **examples/full/agents/fact-checker/DUTIES.md**: Per-agent role declaration — reviewer role with permissions, boundaries (must/must not), handoff participation, isolation constraints
- **examples/full/compliance/regulatory-map.yaml**: `duty_segregation` capability mapping (FINOS AI Governance, FINRA 3110 SOD, SOC 2 logical access)
- **README.md**: SOD pattern section with YAML example, updated directory tree showing DUTIES.md, compliance docs with Salient AI / FINOS attribution

## Context

Part 4 of 4 for the SOD feature (#10). Depends on #13 (adapters).

## Test plan

- [x] `npm run build` passes cleanly
- [x] `node dist/index.js validate -d examples/full --compliance` — full example validates with SOD
- [x] `node dist/index.js audit -d examples/full` — complete audit with SOD section
- [x] DUTIES.md files are well-structured and consistent with spec

## PR Stack

1. Spec + Schema + Types (#11)
2. CLI support (#12)
3. Adapter support (#13)
4. **Examples + docs** (this PR)

🤖 Generated with [Claude Code](https://claude.ai/code)