### PR TITLE
Add gitcron skills: scheduling, task-management, reminders

### DIFF
--- a/skills/reminders/SKILL.md
+++ b/skills/reminders/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: reminders
+description: Set recurring or one-shot reminders that create GitHub issues on schedule — for compliance deadlines, reviews, follow-ups, and check-ins
+license: MIT
+allowed-tools: gitcron cli read write
+metadata:
+  author: open-gitagent
+  version: "1.0.0"
+  category: automation
+---
+
+# Reminders
+
+## Instructions
+
+You can create reminders that automatically create GitHub issues on a schedule or at a specific time. Reminders are defined in `cron.yaml` and compiled to GitHub Actions workflows.
+
+### Reminder types
+
+**Recurring** — Fires repeatedly on a cron schedule:
+```yaml
+- name: weekly-standup
+  type: recurring
+  cron: "0 9 * * 1"
+  action:
+    type: issue
+    title: "Weekly Standup Notes"
+    body: "Time for weekly standup. Update your status."
+    labels: [meeting, reminder]
+    assignees: [team-lead]
+```
+
+**One-shot** — Fires once at a specific time:
+```yaml
+- name: deadline-reminder
+  type: one-shot
+  at: "2026-04-01T09:00:00Z"
+  action:
+    type: issue
+    title: "Q1 Deadline: Final Review"
+```
+
+### When to create reminders
+
+- Compliance deadlines (quarterly reviews, annual audits)
+- Follow-ups after deployments or incidents
+- Recurring meetings or check-ins
+- One-time deadlines or milestones
+- Periodic health checks or reviews
+
+### Common cron patterns for reminders
+
+- `0 9 * * 1` — Every Monday at 9 AM (weekly standup)
+- `0 9 1 * *` — First of month at 9 AM (monthly review)
+- `0 9 1 */3 *` — Quarterly (every 3 months on the 1st)
+- `0 9 1 1 *` — Annual (January 1st)
+- `0 9 * * 1-5` — Every weekday at 9 AM
+
+### Managing reminders
+
+1. `remind-create` — Add a new recurring reminder
+2. `remind-list` — See all reminders
+3. `remind-fire` — Manually trigger a reminder now
+4. `remind-pause` / `remind-resume` — Temporarily disable/enable
+5. After changes, run `gitcron generate` to update workflows
+
+### Best practices
+
+- Use descriptive names in kebab-case: `quarterly-model-review`, not `qmr`
+- Include actionable body text explaining what to do
+- Add appropriate labels for filtering
+- Assign to the responsible team/person
+- For compliance reminders, reference the regulation (e.g., "per SR 11-7")
+
+## Output Format
+
+When creating a reminder, confirm:
+1. Reminder name and schedule (human-readable)
+2. What issue will be created (title, labels, assignees)
+3. Next steps: `gitcron generate` and push

--- a/skills/scheduling/SKILL.md
+++ b/skills/scheduling/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: scheduling
+description: Create and manage scheduled jobs that run as GitHub Actions — schedule agents, commands, code reviews, linting, and any recurring automation
+license: MIT
+allowed-tools: gitcron cli read write
+metadata:
+  author: open-gitagent
+  version: "1.0.0"
+  category: automation
+---
+
+# Scheduling
+
+## Instructions
+
+You can create and manage scheduled jobs that run automatically as GitHub Actions workflows. Each schedule is defined in `cron.yaml` and compiled to `.github/workflows/` files.
+
+### When to create a schedule
+
+Create a schedule when the user wants something to run:
+- On a recurring basis (nightly, weekly, monthly)
+- Automatically without human intervention
+- As a GitHub Actions workflow
+
+### Schedule types
+
+**Agent schedules** — Run a gitagent/gitclaw AI agent:
+```yaml
+- name: nightly-review
+  cron: "0 2 * * *"
+  agent: code-reviewer
+  adapter: claude        # or: openai, gitclaw, system-prompt
+  prompt: "Review all open PRs"
+  branch:
+    strategy: pr         # creates a PR with the agent's changes
+```
+
+**Command schedules** — Run any shell command:
+```yaml
+- name: weekly-lint
+  cron: "0 6 * * 1"
+  command: "npm run lint -- --fix"
+  branch:
+    strategy: commit     # commits directly to base branch
+```
+
+### Cron expression reference
+
+```
+┌───────────── minute (0-59)
+│ ┌─────────── hour (0-23)
+│ │ ┌───────── day of month (1-31)
+│ │ │ ┌─────── month (1-12)
+│ │ │ │ ┌───── day of week (0-7, Sun=0 or 7)
+│ │ │ │ │
+* * * * *
+```
+
+Common patterns:
+- `0 2 * * *` — Daily at 2 AM
+- `0 9 * * 1` — Every Monday at 9 AM
+- `0 0 1 * *` — First of every month at midnight
+- `*/15 * * * *` — Every 15 minutes
+- `0 9 1 */3 *` — Quarterly (first of every 3rd month)
+
+### Branch strategies
+
+| Strategy | Use when |
+|----------|----------|
+| `pr` | Agent makes code changes that need review |
+| `create` | Push a branch without opening a PR |
+| `commit` | Small, safe changes (lint fixes, formatting) |
+| `none` | Read-only tasks (audits, reports, scans) |
+
+### Workflow
+
+1. Use `gitcron` tool with `schedule-list` to see existing schedules
+2. Use `gitcron` tool with appropriate command to create/modify schedules
+3. Edit `cron.yaml` directly for complex configurations
+4. Run `gitcron generate` to compile to GitHub Actions workflows
+5. The workflows will run automatically after push to the repository
+
+### Adapter selection
+
+- **claude** — Best for code changes, complex reasoning. Uses Claude Code via gitagent.
+- **gitclaw** — Full agent runtime with tools, hooks, audit logging, compliance. Best for enterprise use.
+- **openai** — OpenAI API integration via gitagent.
+- **system-prompt** — Generic LLM export.
+
+## Output Format
+
+When creating a schedule, confirm:
+1. Schedule name and cron expression (human-readable)
+2. What it does (agent/command)
+3. Branch strategy chosen and why
+4. Next steps: `gitcron generate` and push

--- a/skills/task-management/SKILL.md
+++ b/skills/task-management/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: task-management
+description: Git-native task tracking with state machine — create, assign, transition, and track tasks where every mutation is a git commit
+license: MIT
+allowed-tools: gitcron cli read write
+metadata:
+  author: open-gitagent
+  version: "1.0.0"
+  category: project-management
+---
+
+# Task Management
+
+## Instructions
+
+You can create and manage tasks tracked as YAML files in `.gitcron/tasks/`. Every task mutation (create, state change, reassign) creates a git commit, giving you a full audit trail.
+
+### When to use tasks
+
+- Track work items discovered during agent execution
+- Break down complex requests into trackable units
+- Assign work to team members or other agents
+- Track progress through defined states
+
+### Task states
+
+Default state machine:
+```
+pending → in_progress → review → done
+  ↓          ↓           ↓
+cancelled  cancelled   (back to in_progress)
+```
+
+Valid transitions:
+- `pending` → `in_progress`, `cancelled`
+- `in_progress` → `review`, `done`, `cancelled`
+- `review` → `in_progress`, `done`
+- `done` → (terminal)
+- `cancelled` → (terminal)
+
+### Creating tasks
+
+Use the `gitcron` tool with `task-create`:
+- Always provide a clear, actionable title
+- Set priority based on urgency: `high`, `medium`, `low`
+- Assign if the responsible person/agent is known
+
+### Updating tasks
+
+Use `task-update` with the task ID (e.g., TASK-001):
+- Only transition to valid next states
+- The tool will reject invalid transitions
+
+### Workflow
+
+1. `task-list` to see current tasks and their states
+2. `task-create` for new work items
+3. `task-update` to progress tasks through states
+4. `task-show` for full details including history
+
+### Best practices
+
+- One task per discrete work item
+- Use descriptive titles that explain the outcome, not the process
+- Set priority based on impact: `high` = blocking/urgent, `medium` = normal, `low` = nice-to-have
+- Move tasks to `review` when they need human verification
+- Move to `done` only when fully complete
+
+## Output Format
+
+When managing tasks, report:
+1. Action taken (created/updated/listed)
+2. Task ID and current state
+3. What changed and why


### PR DESCRIPTION
## Summary
- Add three gitcron skills to `skills/` directory:
  - `scheduling` — Create and manage scheduled jobs as GitHub Actions workflows
  - `task-management` — Git-native task tracking with state machine
  - `reminders` — Set recurring or one-shot reminders that create GitHub issues

## Test plan
- [x] Verify SKILL.md files have valid YAML frontmatter
- [ ] Verify skills are discoverable by the agent runtime

Author: Khush Patel (khush@lyzr.ai) @patel-lyzr