### PR TITLE
fix: progressive skill disclosure in claude-code adapter

### DIFF
--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
-import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
+import { loadAllSkillMetadata } from '../utils/skill-loader.js';
 
 export function exportToClaudeCode(dir: string): string {
   const agentDir = resolve(dir);
@@ -32,20 +32,19 @@ export function exportToClaudeCode(dir: string): string {
     parts.push(duty);
   }
 
-  // Skills — loaded via skill-loader
+  // Skills — loaded via skill-loader (metadata only for progressive disclosure)
   const skillsDir = join(agentDir, 'skills');
-  const skills = loadAllSkills(skillsDir);
+  const skills = loadAllSkillMetadata(skillsDir);
   if (skills.length > 0) {
     const skillParts: string[] = ['## Skills\n'];
     for (const skill of skills) {
-      skillParts.push(`### ${skill.frontmatter.name}`);
-      skillParts.push(skill.frontmatter.description);
-      const tools = getAllowedTools(skill.frontmatter);
-      if (tools.length > 0) {
-        skillParts.push(`Allowed tools: ${tools.join(', ')}`);
+      const skillDirName = skill.directory.split('/').pop()!;
+      skillParts.push(`### ${skill.name}`);
+      skillParts.push(skill.description);
+      if (skill.allowedTools && skill.allowedTools.length > 0) {
+        skillParts.push(`Allowed tools: ${skill.allowedTools.join(', ')}`);
       }
-      skillParts.push('');
-      skillParts.push(skill.instructions);
+      skillParts.push(`Full instructions: \`skills/${skillDirName}/SKILL.md\``);
       skillParts.push('');
     }
     parts.push(skillParts.join('\n'));

--- a/src/utils/skill-loader.ts
+++ b/src/utils/skill-loader.ts
@@ -29,6 +29,7 @@ export interface SkillMetadata {
   name: string;
   description: string;
   license?: string;
+  allowedTools?: string[];
   directory: string;
 }
 
@@ -79,11 +80,13 @@ export function loadSkillMetadata(filePath: string): SkillMetadata {
   }
 
   const fm = yaml.load(frontmatterMatch[1]) as SkillFrontmatter;
+  const tools = getAllowedTools(fm);
 
   return {
     name: fm.name,
     description: fm.description,
     license: fm.license,
+    allowedTools: tools.length > 0 ? tools : undefined,
     directory: join(filePath, '..'),
   };
 }


### PR DESCRIPTION
## Summary

- Switches `claude-code` adapter from `loadAllSkills()` to `loadAllSkillMetadata()`, so `CLAUDE.md` only inlines skill name, description, and allowed-tools with a file path reference — instead of the full `SKILL.md` instructions
- Adds `allowedTools` field to `SkillMetadata` interface so metadata-only loading still surfaces tool restrictions
- `system-prompt` adapter is intentionally unchanged — it produces standalone prompts for LLMs without filesystem access, so full inline is correct there

Saves ~5000 tokens per skill in the CLAUDE.md system prompt. Claude Code reads the full `SKILL.md` on demand when the skill is activated.

Closes #19

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` passes
- [ ] `cd examples/standard && gitagent export --format claude-code` — outputs skill metadata + file paths, not full instructions
- [ ] `cd examples/standard && gitagent export --format system-prompt` — still outputs full instructions (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)