### PR TITLE
feat(adapters): Cursor adapter — export + enhanced import (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Adapters are used by both `export` and `run`. Available adapters:
 | `opencode` | OpenCode instructions + config |
 | `openclaw` | OpenClaw format |
 | `nanobot` | Nanobot format |
+| `cursor` | Cursor `.cursor/rules/*.mdc` files |
 
 ```bash
 # Export to system prompt

--- a/src/adapters/cursor.test.ts
+++ b/src/adapters/cursor.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for the Cursor adapter (export + enhanced import).
+ *
+ * Uses Node.js built-in test runner (node --test).
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  exportToCursor,
+  exportToCursorString,
+  parseMdcFile,
+  readCursorRules,
+} from './cursor.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal gitagent directory in a temp folder. */
+function makeAgentDir(opts: {
+  name?: string;
+  description?: string;
+  soul?: string;
+  rules?: string;
+  skills?: Array<{ name: string; description: string; instructions: string; globs?: string }>;
+}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gitagent-cursor-test-'));
+
+  const manifest = {
+    spec_version: '0.1.0',
+    name: opts.name ?? 'test-agent',
+    version: '0.1.0',
+    description: opts.description ?? 'A test agent',
+  };
+
+  writeFileSync(
+    join(dir, 'agent.yaml'),
+    `spec_version: '0.1.0'\nname: ${manifest.name}\nversion: '0.1.0'\ndescription: '${manifest.description}'\n`,
+    'utf-8',
+  );
+
+  if (opts.soul !== undefined) {
+    writeFileSync(join(dir, 'SOUL.md'), opts.soul, 'utf-8');
+  }
+
+  if (opts.rules !== undefined) {
+    writeFileSync(join(dir, 'RULES.md'), opts.rules, 'utf-8');
+  }
+
+  if (opts.skills) {
+    for (const skill of opts.skills) {
+      const skillDir = join(dir, 'skills', skill.name);
+      mkdirSync(skillDir, { recursive: true });
+      const metadataLine = skill.globs ? `metadata:\n  globs: ${skill.globs}\n` : '';
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---\nname: ${skill.name}\ndescription: '${skill.description}'\n${metadataLine}---\n\n${skill.instructions}\n`,
+        'utf-8',
+      );
+    }
+  }
+
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// parseMdcFile
+// ---------------------------------------------------------------------------
+
+describe('parseMdcFile', () => {
+  test('parses valid frontmatter + body', () => {
+    const content = `---\ndescription: "Hello"\nalwaysApply: true\n---\n\n# Body\n\nSome content.\n`;
+    const result = parseMdcFile(content);
+    assert.equal(result.frontmatter.description, 'Hello');
+    assert.equal(result.frontmatter.alwaysApply, true);
+    assert.match(result.body, /# Body/);
+  });
+
+  test('handles missing frontmatter gracefully', () => {
+    const content = `Just plain markdown, no frontmatter.`;
+    const result = parseMdcFile(content);
+    assert.deepEqual(result.frontmatter, {});
+    assert.equal(result.body, content);
+  });
+
+  test('parses array globs', () => {
+    const content = `---\nglobs:\n  - "*.ts"\n  - "src/**"\nalwaysApply: false\n---\n\nbody\n`;
+    const result = parseMdcFile(content);
+    assert.deepEqual(result.frontmatter.globs, ['*.ts', 'src/**']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCursorRules
+// ---------------------------------------------------------------------------
+
+describe('readCursorRules', () => {
+  test('returns empty array when no .cursor/rules dir exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'empty-'));
+    const rules = readCursorRules(dir);
+    assert.deepEqual(rules, []);
+  });
+
+  test('reads .mdc files from .cursor/rules/', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cursor-rules-'));
+    const rulesDir = join(dir, '.cursor', 'rules');
+    mkdirSync(rulesDir, { recursive: true });
+    writeFileSync(join(rulesDir, 'rule-a.mdc'), `---\nalwaysApply: true\n---\n\nbody a\n`, 'utf-8');
+    writeFileSync(join(rulesDir, 'rule-b.mdc'), `---\nalwaysApply: false\n---\n\nbody b\n`, 'utf-8');
+    // Non-.mdc file should be ignored
+    writeFileSync(join(rulesDir, 'ignored.md'), 'should be ignored', 'utf-8');
+
+    const rules = readCursorRules(dir);
+    assert.equal(rules.length, 2);
+    const filenames = rules.map(r => r.filename).sort();
+    assert.deepEqual(filenames, ['rule-a.mdc', 'rule-b.mdc']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportToCursor — global rule
+// ---------------------------------------------------------------------------
+
+describe('exportToCursor — global rule', () => {
+  test('emits alwaysApply rule when SOUL.md exists', () => {
+    const dir = makeAgentDir({ soul: '# I am a soul', description: 'My agent' });
+    const exp = exportToCursor(dir);
+    const global = exp.rules.find(r => r.content.includes('alwaysApply: true'));
+    assert.ok(global, 'Expected an alwaysApply: true rule');
+    assert.match(global!.content, /I am a soul/);
+  });
+
+  test('includes RULES.md content in global rule', () => {
+    const dir = makeAgentDir({ soul: '# Soul', rules: '# Never lie' });
+    const exp = exportToCursor(dir);
+    const global = exp.rules.find(r => r.content.includes('alwaysApply: true'));
+    assert.ok(global);
+    assert.match(global!.content, /Never lie/);
+  });
+
+  test('no global rule emitted when neither SOUL.md nor RULES.md exists', () => {
+    const dir = makeAgentDir({});
+    const exp = exportToCursor(dir);
+    const global = exp.rules.filter(r => r.content.includes('alwaysApply: true'));
+    assert.equal(global.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportToCursor — skill rules
+// ---------------------------------------------------------------------------
+
+describe('exportToCursor — skill rules', () => {
+  test('emits one skill rule per skill', () => {
+    const dir = makeAgentDir({
+      skills: [
+        { name: 'code-review', description: 'Reviews code', instructions: 'Check for bugs.' },
+        { name: 'docs-writer', description: 'Writes docs', instructions: 'Write clear docs.' },
+      ],
+    });
+    const exp = exportToCursor(dir);
+    const skillRules = exp.rules.filter(r => !r.content.includes('alwaysApply: true'));
+    assert.equal(skillRules.length, 2);
+  });
+
+  test('skill rule filename is slugified skill name', () => {
+    const dir = makeAgentDir({
+      skills: [{ name: 'my-skill', description: 'Skill', instructions: 'Do stuff.' }],
+    });
+    const exp = exportToCursor(dir);
+    const rule = exp.rules.find(r => r.filename === 'my-skill.mdc');
+    assert.ok(rule, 'Expected my-skill.mdc');
+  });
+
+  test('skill rule includes globs when metadata.globs is set', () => {
+    const dir = makeAgentDir({
+      skills: [
+        {
+          name: 'api-handler',
+          description: 'API handler review',
+          instructions: 'Check endpoints.',
+          globs: 'src/api/** *.route.ts',
+        },
+      ],
+    });
+    const exp = exportToCursor(dir);
+    const rule = exp.rules.find(r => r.filename === 'api-handler.mdc');
+    assert.ok(rule);
+    assert.match(rule!.content, /globs:/);
+    assert.match(rule!.content, /src\/api\/\*\*/);
+    assert.match(rule!.content, /\*\.route\.ts/);
+  });
+
+  test('skill rule has alwaysApply: false', () => {
+    const dir = makeAgentDir({
+      skills: [{ name: 'linter', description: 'Lints', instructions: 'Lint everything.' }],
+    });
+    const exp = exportToCursor(dir);
+    const rule = exp.rules.find(r => r.filename === 'linter.mdc');
+    assert.ok(rule);
+    assert.match(rule!.content, /alwaysApply: false/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportToCursorString
+// ---------------------------------------------------------------------------
+
+describe('exportToCursorString', () => {
+  test('returns string with file path headers', () => {
+    const dir = makeAgentDir({
+      soul: '# Soul',
+      skills: [{ name: 'test-skill', description: 'Test', instructions: 'Do test.' }],
+    });
+    const output = exportToCursorString(dir);
+    assert.match(output, /# === \.cursor\/rules\//);
+    assert.match(output, /\.mdc ===/);
+  });
+
+  test('output is non-empty string', () => {
+    const dir = makeAgentDir({ soul: '# Soul' });
+    const output = exportToCursorString(dir);
+    assert.ok(output.length > 0);
+    assert.equal(typeof output, 'string');
+  });
+});

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -1,0 +1,229 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, resolve, basename } from 'node:path';
+import yaml from 'js-yaml';
+import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
+import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
+
+/**
+ * Export a gitagent to Cursor rules format.
+ *
+ * Cursor uses:
+ *   - `.cursor/rules/<name>.mdc`  (YAML frontmatter + markdown content)
+ *
+ * Frontmatter fields:
+ *   - `description`   Human-readable summary
+ *   - `globs`         Array of file patterns to scope the rule (optional)
+ *   - `alwaysApply`   boolean — true for global rules (SOUL.md + RULES.md)
+ *
+ * Mapping:
+ *   - SOUL.md + RULES.md  → `.cursor/rules/<agent-name>.mdc`  (alwaysApply: true)
+ *   - Each skill          → `.cursor/rules/<skill-name>.mdc`  (alwaysApply: false, globs from metadata.globs)
+ */
+export interface CursorRule {
+  /** Destination filename inside `.cursor/rules/` (without directory) */
+  filename: string;
+  /** Full .mdc content (YAML frontmatter + markdown body) */
+  content: string;
+}
+
+export interface CursorExport {
+  rules: CursorRule[];
+}
+
+export function exportToCursor(dir: string): CursorExport {
+  const agentDir = resolve(dir);
+  const manifest = loadAgentManifest(agentDir);
+
+  const rules: CursorRule[] = [];
+
+  // --- Global rule: SOUL.md + RULES.md → alwaysApply: true ---
+  const globalRule = buildGlobalRule(agentDir, manifest);
+  if (globalRule) {
+    rules.push(globalRule);
+  }
+
+  // --- Skill rules: one .mdc per skill ---
+  const skillsDir = join(agentDir, 'skills');
+  const skills = loadAllSkills(skillsDir);
+  for (const skill of skills) {
+    rules.push(buildSkillRule(skill));
+  }
+
+  return { rules };
+}
+
+/**
+ * Export as a single string showing the files that would be written.
+ * Used by `gitagent export --format cursor`.
+ */
+export function exportToCursorString(dir: string): string {
+  const exp = exportToCursor(dir);
+  const parts: string[] = [];
+
+  for (const rule of exp.rules) {
+    parts.push(`# === .cursor/rules/${rule.filename} ===`);
+    parts.push(rule.content);
+    parts.push('');
+  }
+
+  return parts.join('\n').trimEnd() + '\n';
+}
+
+/**
+ * Build the global alwaysApply rule from SOUL.md and RULES.md.
+ * Returns null if neither file exists (no global rule to emit).
+ */
+function buildGlobalRule(
+  agentDir: string,
+  manifest: ReturnType<typeof loadAgentManifest>,
+): CursorRule | null {
+  const soul = loadFileIfExists(join(agentDir, 'SOUL.md'));
+  const rules = loadFileIfExists(join(agentDir, 'RULES.md'));
+
+  if (!soul && !rules) return null;
+
+  const frontmatter: Record<string, unknown> = {
+    description: manifest.description,
+    alwaysApply: true,
+  };
+
+  const bodyParts: string[] = [];
+
+  if (soul) {
+    bodyParts.push('## Identity & Soul');
+    bodyParts.push('');
+    bodyParts.push(soul.trim());
+  }
+
+  if (rules) {
+    if (bodyParts.length > 0) bodyParts.push('');
+    bodyParts.push('## Rules & Constraints');
+    bodyParts.push('');
+    bodyParts.push(rules.trim());
+  }
+
+  const content = buildMdcFile(frontmatter, bodyParts.join('\n'));
+  const agentSlug = slugify(manifest.name);
+
+  return {
+    filename: `${agentSlug}.mdc`,
+    content,
+  };
+}
+
+/**
+ * Build a scoped skill rule from a parsed skill.
+ * Uses metadata.globs for file scoping when available.
+ */
+function buildSkillRule(
+  skill: import('../utils/skill-loader.js').ParsedSkill,
+): CursorRule {
+  const fm = skill.frontmatter;
+
+  const frontmatter: Record<string, unknown> = {
+    description: fm.description,
+    alwaysApply: false,
+  };
+
+  // Globs: read from metadata.globs (space or comma separated) or allowed-tools scope hint
+  const globs = parseGlobs(fm.metadata?.['globs']);
+  if (globs.length > 0) {
+    frontmatter['globs'] = globs;
+  }
+
+  const bodyParts: string[] = [];
+
+  // Skill heading
+  bodyParts.push(`# ${fm.name}`);
+  bodyParts.push('');
+  bodyParts.push(skill.instructions.trim());
+
+  // Allowed tools note
+  const toolsList = getAllowedTools(fm);
+  if (toolsList.length > 0) {
+    bodyParts.push('');
+    bodyParts.push(`**Allowed tools:** ${toolsList.join(', ')}`);
+  }
+
+  const content = buildMdcFile(frontmatter, bodyParts.join('\n'));
+
+  return {
+    filename: `${slugify(fm.name)}.mdc`,
+    content,
+  };
+}
+
+/**
+ * Render a .mdc file: YAML frontmatter block + markdown body.
+ */
+function buildMdcFile(frontmatter: Record<string, unknown>, body: string): string {
+  const fm = yaml.dump(frontmatter, { lineWidth: 120 }).trimEnd();
+  return `---\n${fm}\n---\n\n${body.trim()}\n`;
+}
+
+/**
+ * Parse a globs string (space or comma separated) into an array.
+ * Returns an empty array if the input is falsy or blank.
+ *
+ * Examples:
+ *   "*.ts src/api/**"   → ["*.ts", "src/api/**"]
+ *   "*.py,tests/**"     → ["*.py", "tests/**"]
+ */
+function parseGlobs(raw: string | undefined): string[] {
+  if (!raw || raw.trim() === '') return [];
+  return raw
+    .split(/[\s,]+/)
+    .map(g => g.trim())
+    .filter(Boolean);
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+// ---------------------------------------------------------------------------
+// Enhanced import: read .cursor/rules/*.mdc → gitagent skills
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single .mdc file into its frontmatter and body.
+ */
+export interface MdcFile {
+  frontmatter: {
+    description?: string;
+    globs?: string | string[];
+    alwaysApply?: boolean;
+  };
+  body: string;
+}
+
+export function parseMdcFile(content: string): MdcFile {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n*([\s\S]*)$/);
+  if (!match) {
+    return { frontmatter: {}, body: content.trim() };
+  }
+  const frontmatter = (yaml.load(match[1]) ?? {}) as MdcFile['frontmatter'];
+  return { frontmatter, body: match[2].trim() };
+}
+
+/**
+ * Read all .mdc files from a `.cursor/rules/` directory.
+ * Returns a list of { filename, parsed } objects, or an empty array if the
+ * directory does not exist.
+ */
+export function readCursorRules(
+  sourceDir: string,
+): Array<{ filename: string; parsed: MdcFile }> {
+  const rulesDir = join(resolve(sourceDir), '.cursor', 'rules');
+  if (!existsSync(rulesDir)) return [];
+
+  return readdirSync(rulesDir)
+    .filter(f => f.endsWith('.mdc'))
+    .map(filename => ({
+      filename,
+      parsed: parseMdcFile(readFileSync(join(rulesDir, filename), 'utf-8')),
+    }));
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -6,3 +6,4 @@ export { exportToOpenClawString, exportToOpenClaw } from './openclaw.js';
 export { exportToNanobotString, exportToNanobot } from './nanobot.js';
 export { exportToCopilotString, exportToCopilot } from './copilot.js';
 export { exportToOpenCodeString, exportToOpenCode } from './opencode.js';
+export { exportToCursorString, exportToCursor } from './cursor.js';

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -10,6 +10,7 @@ import {
   exportToNanobotString,
   exportToCopilotString,
   exportToOpenCodeString,
+  exportToCursorString,
 } from '../adapters/index.js';
 import { exportToLyzrString } from '../adapters/lyzr.js';
 import { exportToGitHubString } from '../adapters/github.js';
@@ -22,7 +23,7 @@ interface ExportOptions {
 
 export const exportCommand = new Command('export')
   .description('Export agent to other formats')
-  .requiredOption('-f, --format <format>', 'Export format (system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode)')
+  .requiredOption('-f, --format <format>', 'Export format (system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor)')
   .option('-d, --dir <dir>', 'Agent directory', '.')
   .option('-o, --output <output>', 'Output file path')
   .action(async (options: ExportOptions) => {
@@ -65,9 +66,12 @@ export const exportCommand = new Command('export')
         case 'opencode':
           result = exportToOpenCodeString(dir);
           break;
+        case 'cursor':
+          result = exportToCursorString(dir);
+          break;
         default:
           error(`Unknown format: ${options.format}`);
-          info('Supported formats: system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode');
+          info('Supported formats: system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor');
           process.exit(1);
       }
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync } from 
 import { join, resolve, basename } from 'node:path';
 import yaml from 'js-yaml';
 import { error, heading, info, success, warn } from '../utils/format.js';
+import { readCursorRules } from '../adapters/cursor.js';
 
 interface ImportOptions {
   from: string;
@@ -87,25 +88,89 @@ function importFromClaude(sourcePath: string, targetDir: string): void {
 function importFromCursor(sourcePath: string, targetDir: string): void {
   const sourceDir = resolve(sourcePath);
 
-  // Look for .cursorrules or AGENTS.md
+  const dirName = basename(sourceDir);
+  const agentName = dirName.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+
+  // --- Enhanced import: read .cursor/rules/*.mdc first ---
+  const mdcRules = readCursorRules(sourceDir);
+
+  if (mdcRules.length > 0) {
+    info(`Found ${mdcRules.length} rule(s) in .cursor/rules/`);
+
+    // Separate global (alwaysApply) rules from skill rules
+    const globalRules = mdcRules.filter(r => r.parsed.frontmatter.alwaysApply === true);
+    const skillRules = mdcRules.filter(r => r.parsed.frontmatter.alwaysApply !== true);
+
+    // Build SOUL.md from global alwaysApply rules
+    if (globalRules.length > 0) {
+      const soulParts: string[] = [`# Soul — imported from Cursor rules\n`];
+      for (const rule of globalRules) {
+        if (rule.parsed.body) {
+          soulParts.push(rule.parsed.body);
+          soulParts.push('');
+        }
+      }
+      writeFileSync(join(targetDir, 'SOUL.md'), soulParts.join('\n').trimEnd() + '\n', 'utf-8');
+      success(`Created SOUL.md (from ${globalRules.length} alwaysApply rule(s))`);
+    }
+
+    // Convert scoped skill rules to skills/
+    const skillNames: string[] = [];
+    for (const rule of skillRules) {
+      const skillName = rule.filename.replace(/\.mdc$/, '');
+      const skillDir = join(targetDir, 'skills', skillName);
+      mkdirSync(skillDir, { recursive: true });
+
+      // Build SKILL.md frontmatter
+      const fm: Record<string, unknown> = {
+        name: skillName,
+        description: rule.parsed.frontmatter.description ?? `Imported from .cursor/rules/${rule.filename}`,
+      };
+
+      // Carry globs into metadata for round-trip fidelity
+      const globs = rule.parsed.frontmatter.globs;
+      if (globs) {
+        const globStr = Array.isArray(globs) ? globs.join(' ') : globs;
+        fm['metadata'] = { globs: globStr };
+      }
+
+      const skillMd = `---\n${yaml.dump(fm).trimEnd()}\n---\n\n${(rule.parsed.body ?? '').trim()}\n`;
+      writeFileSync(join(skillDir, 'SKILL.md'), skillMd, 'utf-8');
+      skillNames.push(skillName);
+      success(`Created skill: ${skillName}`);
+    }
+
+    const agentYaml = {
+      spec_version: '0.1.0',
+      name: agentName,
+      version: '0.1.0',
+      description: `Imported from Cursor project: ${dirName}`,
+      ...(skillNames.length > 0 ? { skills: skillNames } : {}),
+    };
+    writeFileSync(join(targetDir, 'agent.yaml'), yaml.dump(agentYaml), 'utf-8');
+    success('Created agent.yaml');
+
+    return;
+  }
+
+  // --- Legacy fallback: .cursorrules or AGENTS.md ---
   let instructions = '';
   const cursorRulesPath = join(sourceDir, '.cursorrules');
   const agentsMdPath = join(sourceDir, 'AGENTS.md');
 
   if (existsSync(cursorRulesPath)) {
     instructions = readFileSync(cursorRulesPath, 'utf-8');
-    info('Found .cursorrules');
+    info('Found .cursorrules (legacy)');
   } else if (existsSync(agentsMdPath)) {
     instructions = readFileSync(agentsMdPath, 'utf-8');
     info('Found AGENTS.md');
   } else {
-    throw new Error('No .cursorrules or AGENTS.md found in source directory');
+    throw new Error('No .cursor/rules/ directory, .cursorrules, or AGENTS.md found in source directory');
   }
 
-  const dirName = basename(sourceDir);
   const agentYaml = {
     spec_version: '0.1.0',
-    name: dirName.toLowerCase().replace(/[^a-z0-9-]/g, '-'),
+    name: agentName,
     version: '0.1.0',
     description: `Imported from Cursor project: ${dirName}`,
   };


### PR DESCRIPTION
Implements #34 ([Adapter] Cursor, tagged **help wanted**).

## What this adds

### Export: `gitagent export --format cursor`

Generates `.cursor/rules/*.mdc` files from a gitagent directory:

| Source | Output |
|--------|--------|
| `SOUL.md` + `RULES.md` | `<agent-name>.mdc` with `alwaysApply: true` |
| Each skill in `skills/` | `<skill-name>.mdc` with `alwaysApply: false` |
| `metadata.globs` in SKILL.md | `globs:` array in .mdc frontmatter |

Skills without `metadata.globs` get no globs field (Cursor applies them globally by default).

Example output for a skill with globs:
```yaml
---
description: Reviews API handlers for correctness and security
alwaysApply: false
globs:
  - src/api/**
  - '*.route.ts'
---

# API Review

Check all endpoints for auth, input validation, and error handling.
```

### Enhanced Import: `gitagent import --from cursor`

Reads `.cursor/rules/*.mdc` directory (not just legacy `.cursorrules`):

- `alwaysApply: true` rules → `SOUL.md`  
- Scoped skill rules → `skills/<name>/SKILL.md`  
- Globs preserved in `metadata.globs` for round-trip fidelity  
- Falls back to `.cursorrules` → `AGENTS.md` when no `.cursor/rules/` found  

### Mapping document

| gitagent field | Cursor output | Notes |
|----------------|---------------|-------|
| `SOUL.md` | `alwaysApply: true` .mdc body | Grouped with RULES.md under agent slug |
| `RULES.md` | `alwaysApply: true` .mdc body | Appended to same global rule |
| `manifest.description` | `description:` frontmatter | Global rule only |
| `skill.frontmatter.description` | `description:` frontmatter | Per-skill rule |
| `skill.metadata.globs` | `globs:` array | Space/comma separated → array |
| `compliance` | Dropped | Cursor has no compliance primitive |
| `knowledge/` | Dropped | No Cursor equivalent |

## Tests

14 tests, 5 suites — all pass:

```
# tests 14
# suites 5
# pass 14
# fail 0
```

Covers: `parseMdcFile`, `readCursorRules`, export global/skill rules, globs, slugification, string output format.

## Files changed

- `src/adapters/cursor.ts` — new adapter (export + import helpers)
- `src/adapters/cursor.test.ts` — 14 tests
- `src/adapters/index.ts` — re-export `exportToCursorString`, `exportToCursor`
- `src/commands/export.ts` — wire `cursor` case + update format list
- `src/commands/import.ts` — enhanced `importFromCursor` using `readCursorRules`
- `README.md` — add `cursor` to adapter table

**Run**: `gitagent export --format cursor` is not applicable (Cursor is an IDE), so no run adapter — as noted in the issue.