### PR TITLE
fix: use process.exitCode instead of process.exit() so runner finally blocks clean up temp files

### DIFF
--- a/src/runners/claude.ts
+++ b/src/runners/claude.ts
@@ -96,10 +96,11 @@ export function runWithClaude(agentDir: string, manifest: AgentManifest, options
     if (result.error) {
       error(`Failed to launch Claude Code: ${result.error.message}`);
       info('Make sure Claude Code CLI is installed: npm install -g @anthropic-ai/claude-code');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
-    process.exit(result.status ?? 0);
+    process.exitCode = result.status ?? 0;
   } finally {
     for (const f of tmpFiles) {
       try { unlinkSync(f); } catch { /* ignore */ }

--- a/src/runners/crewai.ts
+++ b/src/runners/crewai.ts
@@ -25,10 +25,11 @@ export function runWithCrewAI(agentDir: string, _manifest: AgentManifest): void 
     if (result.error) {
       error(`Failed to run CrewAI: ${result.error.message}`);
       info('Make sure the crewai CLI is installed: pip install crewai');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
-    process.exit(result.status ?? 0);
+    process.exitCode = result.status ?? 0;
   } finally {
     try { unlinkSync(tmpFile); } catch { /* ignore */ }
   }

--- a/src/runners/nanobot.ts
+++ b/src/runners/nanobot.ts
@@ -58,10 +58,11 @@ export function runWithNanobot(agentDir: string, manifest: AgentManifest, option
       error(`Failed to launch Nanobot: ${result.error.message}`);
       info('Install Nanobot with: pip install nanobot-ai');
       info('Or: uv tool install nanobot-ai');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
-    process.exit(result.status ?? 0);
+    process.exitCode = result.status ?? 0;
   } finally {
     try { rmSync(tmpConfigDir, { recursive: true, force: true }); } catch { /* ignore */ }
   }

--- a/src/runners/openai.ts
+++ b/src/runners/openai.ts
@@ -32,10 +32,11 @@ export function runWithOpenAI(agentDir: string, _manifest: AgentManifest): void 
     if (result.error) {
       error(`Failed to run Python: ${result.error.message}`);
       info('Make sure python3 is installed and the openai-agents package is available');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
-    process.exit(result.status ?? 0);
+    process.exitCode = result.status ?? 0;
   } finally {
     try { unlinkSync(tmpFile); } catch { /* ignore */ }
   }

--- a/src/runners/openclaw.ts
+++ b/src/runners/openclaw.ts
@@ -118,10 +118,11 @@ export function runWithOpenClaw(agentDir: string, manifest: AgentManifest, optio
     if (result.error) {
       error(`Failed to launch OpenClaw: ${result.error.message}`);
       info('Make sure OpenClaw is installed: npm install -g openclaw@latest');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
 
-    process.exit(result.status ?? 0);
+    process.exitCode = result.status ?? 0;
   } finally {
     // Cleanup temp workspace
     try { rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* ignore */ }


### PR DESCRIPTION
## What

Replace `process.exit(N)` with `process.exitCode = N; return` inside try/finally blocks in all five runners: `claude`, `openai`, `crewai`, `nanobot`, `openclaw`.

## Why

`process.exit()` terminates Node.js immediately without running any pending `finally` blocks. Every runner in this project follows the same pattern:

```ts
try {
  const result = spawnSync(...);
  if (result.error) {
    process.exit(1); // finally SKIPPED
  }
  process.exit(result.status ?? 0); // finally SKIPPED
} finally {
  unlinkSync(tmpFile); // never executes
}
```

Because the finally block is skipped, temporary files written to `/tmp` — including system prompt content, agent configs, and API credentials passed via environment — are left on disk indefinitely after every invocation.

Using `process.exitCode = N; return` lets the finally block execute first, removing all temporary files, and then the process exits naturally with the set exit code.

Affected runners:
- `src/runners/claude.ts` — system prompt + hooks settings JSON in /tmp
- `src/runners/openai.ts` — generated Python script in /tmp
- `src/runners/crewai.ts` — generated YAML config in /tmp
- `src/runners/nanobot.ts` — config dir + system prompt file in /tmp
- `src/runners/openclaw.ts` — full workspace directory in /tmp

## How Tested

- [x] `npm run build` passes
- [x] `gitagent validate` passes on example agents
- [x] Manual testing (describe below)

Manually confirmed that after `gitagent run` completes, no leftover `/tmp/gitagent-*` files remain.

## Checklist

- [x] My code follows the existing style of this project
- [x] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)