### PR TITLE
fix: resolve duplicate option registration in export and import commands

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -25,8 +25,7 @@ interface ExportOptions {
 
 export const exportCommand = new Command('export')
   .description('Export agent to other formats')
-.requiredOption('-f, --format <format>', 'Export format (system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, gemini)')
-.requiredOption('-f, --format <format>', 'Export format (system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, codex)')
+.requiredOption('-f, --format <format>', 'Export format (system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, gemini, codex)')
   .option('-d, --dir <dir>', 'Agent directory', '.')
   .option('-o, --output <output>', 'Output file path')
   .action(async (options: ExportOptions) => {
@@ -75,12 +74,12 @@ export const exportCommand = new Command('export')
 case 'gemini':
           result = exportToGeminiString(dir);
           break;
+        case 'codex':
+          result = exportToCodexString(dir);
+          break;
         default:
           error(`Unknown format: ${options.format}`);
-          info('Supported formats: system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, gemini');
-case 'codex':
-          result = exportToCodexString(dir);
-          info('Supported formats: system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, codex');
+          info('Supported formats: system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, gemini, codex');
           process.exit(1);
       }
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -521,8 +521,7 @@ function parseSections(markdown: string): [string, string][] {
 
 export const importCommand = new Command('import')
   .description('Import from other agent formats')
-.requiredOption('--from <format>', 'Source format (claude, cursor, crewai, opencode, gemini)')
-.requiredOption('--from <format>', 'Source format (claude, cursor, crewai, opencode, codex)')
+.requiredOption('--from <format>', 'Source format (claude, cursor, crewai, opencode, gemini, codex)')
   .argument('<path>', 'Source file or directory path')
   .option('-d, --dir <dir>', 'Target directory', '.')
   .action((sourcePath: string, options: ImportOptions) => {
@@ -549,12 +548,12 @@ export const importCommand = new Command('import')
 case 'gemini':
           importFromGemini(sourcePath, targetDir);
           break;
+        case 'codex':
+          importFromCodex(sourcePath, targetDir);
+          break;
         default:
           error(`Unknown format: ${options.from}`);
-          info('Supported formats: claude, cursor, crewai, opencode, gemini');
-case 'codex':
-          importFromCodex(sourcePath, targetDir);
-          info('Supported formats: claude, cursor, crewai, opencode, codex');
+          info('Supported formats: claude, cursor, crewai, opencode, gemini, codex');
           process.exit(1);
       }
 


### PR DESCRIPTION
## What
Fix duplicate `.requiredOption()` registration in `export` and `import` commands that crashes the entire CLI on startup.

## Why
After installing v0.1.0 via `npm i -g @open-gitagent/gitagent`, every CLI command fails — not just `export`/`import`, but even `gitagent init` and `gitagent info` — because commander throws during module loading.

Two bugs in both `export.ts` and `import.ts`:
1. `.requiredOption()` called twice with the same flag (once for gemini, once for codex)
2. `case 'codex'` placed inside `default` branch, unreachable

Closes #53

## How Tested
- [x] `npm run build` passes
- [x] `gitagent validate` passes on example agents
- [x] Manual testing (describe below)

After patching:
- `gitagent --version` → `0.1.0` (no crash)
- `gitagent info` → displays agent summary
- `gitagent validate` → validation passed
- `gitagent export --format claude-code` → correct output

## Checklist
- [x] My code follows the existing style of this project
- [ ] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)