### PR TITLE
fix(issue,53): fixed duplicated required options in export and import

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -11,8 +11,8 @@ import {
   exportToCopilotString,
   exportToOpenCodeString,
   exportToCursorString,
-exportToGeminiString,
-exportToCodexString,
+  exportToGeminiString,
+  exportToCodexString,
 } from '../adapters/index.js';
 import { exportToLyzrString } from '../adapters/lyzr.js';
 import { exportToGitHubString } from '../adapters/github.js';
@@ -25,8 +25,7 @@ interface ExportOptions {
 
 export const exportCommand = new Command('export')
   .description('Export agent to other formats')
-.requiredOption('-f, --format <format>', 'Export format (system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, gemini)')
-.requiredOption('-f, --format <format>', 'Export format (system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, codex)')
+  .requiredOption('-f, --format <format>', 'Export format (system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, gemini, codex)')
   .option('-d, --dir <dir>', 'Agent directory', '.')
   .option('-o, --output <output>', 'Output file path')
   .action(async (options: ExportOptions) => {
@@ -72,13 +71,13 @@ export const exportCommand = new Command('export')
         case 'cursor':
           result = exportToCursorString(dir);
           break;
-case 'gemini':
+        case 'gemini':
           result = exportToGeminiString(dir);
           break;
         default:
           error(`Unknown format: ${options.format}`);
           info('Supported formats: system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, gemini');
-case 'codex':
+        case 'codex':
           result = exportToCodexString(dir);
           info('Supported formats: system-prompt, claude-code, openai, crewai, openclaw, nanobot, lyzr, github, copilot, opencode, cursor, codex');
           process.exit(1);

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -451,7 +451,7 @@ function importFromGemini(sourcePath: string, targetDir: string): void {
     else if (approvalMode === 'default') hitl = 'conditional';
     else if (approvalMode === 'yolo') hitl = 'none';
     else if (approvalMode === 'auto_edit') hitl = 'advisory';
-    
+
     if (hitl) {
       agentYaml.compliance = {
         supervision: {
@@ -521,8 +521,7 @@ function parseSections(markdown: string): [string, string][] {
 
 export const importCommand = new Command('import')
   .description('Import from other agent formats')
-.requiredOption('--from <format>', 'Source format (claude, cursor, crewai, opencode, gemini)')
-.requiredOption('--from <format>', 'Source format (claude, cursor, crewai, opencode, codex)')
+  .requiredOption('--from <format>', 'Source format (claude, cursor, crewai, opencode, gemini, codex)')
   .argument('<path>', 'Source file or directory path')
   .option('-d, --dir <dir>', 'Target directory', '.')
   .action((sourcePath: string, options: ImportOptions) => {
@@ -546,13 +545,13 @@ export const importCommand = new Command('import')
         case 'opencode':
           importFromOpenCode(sourcePath, targetDir);
           break;
-case 'gemini':
+        case 'gemini':
           importFromGemini(sourcePath, targetDir);
           break;
         default:
           error(`Unknown format: ${options.from}`);
           info('Supported formats: claude, cursor, crewai, opencode, gemini');
-case 'codex':
+        case 'codex':
           importFromCodex(sourcePath, targetDir);
           info('Supported formats: claude, cursor, crewai, opencode, codex');
           process.exit(1);


### PR DESCRIPTION
## What
Fixed the duplicate requiredOption in both import.ts and export.ts

## Why
- The execution of the main command is currently broken, as stated in issue #53 
- Be aware that I'm not a javascript/typescript dev, I just followed the conventions I saw on the repo.

Closes #

## How Tested
- [X] `npm run build` passes
<img width="1019" height="145" alt="image" src="https://github.com/user-attachments/assets/71938348-5e81-4f24-891e-e9bbf4e18ba5" />

- [X] `gitagent validate` passes on example agents
<img width="1019" height="352" alt="image" src="https://github.com/user-attachments/assets/28f26b43-c117-4fa1-9f54-09d790f9fd21" />


- [X] Manual testing (describe below)
Manual testing was done by just using the generated build to run gitagent validate and the import and export commands

Export:
<img width="1238" height="301" alt="image" src="https://github.com/user-attachments/assets/210b5ce8-c7bb-4f4c-816e-04fffdef9ccd" />

Import:
<img width="1238" height="336" alt="image" src="https://github.com/user-attachments/assets/0c5d62bf-c71a-424d-82b2-eaef8339d43f" />


## Checklist
- [X] My code follows the existing style of this project
- [N/A] I have added/updated tests (if applicable)
- [N/A] I have updated documentation (if applicable)
- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
