### PR TITLE
feat: add mcp_servers to agent.yaml for portable MCP server definitions

### DIFF
--- a/examples/full/agent.yaml
+++ b/examples/full/agent.yaml
@@ -132,6 +132,18 @@ compliance:
         required_roles: [analyst, reviewer]
         approval_required: true
     enforcement: strict
+mcp_servers:
+  regulatory-db:
+    command: npx
+    args:
+      - "-y"
+      - "@compliance/mcp-regulatory-search"
+    env:
+      REG_DB_URL: "${REG_DB_URL}"
+  compliance-api:
+    url: "https://compliance-api.internal/mcp"
+    headers:
+      Authorization: "Bearer ${COMPLIANCE_API_TOKEN}"
 tags:
   - compliance
   - financial-services

--- a/spec/schemas/agent-yaml.schema.json
+++ b/spec/schemas/agent-yaml.schema.json
@@ -228,6 +228,13 @@
       "items": { "type": "string" },
       "uniqueItems": true
     },
+    "mcp_servers": {
+      "type": "object",
+      "description": "MCP server definitions. Keys are server names. Each server is either stdio-based (command) or HTTP-based (url).",
+      "additionalProperties": {
+        "$ref": "#/$defs/mcp_server_config"
+      }
+    },
     "metadata": {
       "type": "object",
       "description": "Arbitrary key-value metadata. Values must be strings, numbers, or booleans.",
@@ -243,6 +250,42 @@
   "additionalProperties": false,
 
   "$defs": {
+    "mcp_server_config": {
+      "type": "object",
+      "description": "Configuration for a single MCP server (stdio or HTTP)",
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Executable command for stdio-based servers"
+        },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments for the command"
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Environment variables. Use ${VAR} for interpolation."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL for HTTP-based (SSE/streamable HTTP) MCP servers"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "HTTP headers for URL-based servers"
+        }
+      },
+      "oneOf": [
+        { "required": ["command"] },
+        { "required": ["url"] }
+      ],
+      "additionalProperties": false
+    },
+
     "dependency": {
       "type": "object",
       "required": ["name", "source"],

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkillMetadata } from '../utils/skill-loader.js';
+import { buildMcpServersConfig } from './shared.js';
 
 /**
  * Merge parent agent content into the current agent directory.
@@ -51,10 +52,53 @@ function mergeParentContent(agentDir: string, parentDir: string): {
   return { mergedSoul, mergedRules };
 }
 
-export function exportToClaudeCode(dir: string): string {
+/**
+ * Export a gitagent to Claude Code format.
+ *
+ * Claude Code uses:
+ *   - CLAUDE.md      (custom agent instructions, project root)
+ *   - .mcp.json      (MCP server configuration)
+ */
+export interface ClaudeCodeExport {
+  /** Content for CLAUDE.md */
+  instructions: string;
+  /** Content for .mcp.json (null if no MCP servers defined) */
+  mcpConfig: Record<string, unknown> | null;
+}
+
+export function exportToClaudeCode(dir: string): ClaudeCodeExport {
   const agentDir = resolve(dir);
   const manifest = loadAgentManifest(agentDir);
 
+  const instructions = buildInstructions(agentDir, manifest);
+  const mcpServers = buildMcpServersConfig(manifest.mcp_servers);
+  const mcpConfig = mcpServers ? { mcpServers } : null;
+
+  return { instructions, mcpConfig };
+}
+
+/**
+ * Export as a single string (for `gitagent export -f claude-code`).
+ */
+export function exportToClaudeCodeString(dir: string): string {
+  const exp = exportToClaudeCode(dir);
+  const parts: string[] = [];
+
+  parts.push('# === CLAUDE.md ===');
+  parts.push(exp.instructions);
+
+  if (exp.mcpConfig) {
+    parts.push('\n# === .mcp.json ===');
+    parts.push(JSON.stringify(exp.mcpConfig, null, 2));
+  }
+
+  return parts.join('\n');
+}
+
+function buildInstructions(
+  agentDir: string,
+  manifest: ReturnType<typeof loadAgentManifest>,
+): string {
   // Check for installed parent agent (extends)
   const parentDir = join(agentDir, '.gitagent', 'parent');
   const hasParent = existsSync(parentDir) && existsSync(join(parentDir, 'agent.yaml'));

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -3,7 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
-import { buildComplianceSection } from './shared.js';
+import { buildComplianceSection, buildMcpServersConfig } from './shared.js';
 
 /**
  * Export a gitagent to OpenAI Codex CLI format.
@@ -183,6 +183,12 @@ function buildConfig(manifest: ReturnType<typeof loadAgentManifest>): Record<str
       // Only emit provider when non-default — Codex defaults to openai
       config.provider = provider;
     }
+  }
+
+  // MCP servers
+  const mcpServers = buildMcpServersConfig(manifest.mcp_servers);
+  if (mcpServers) {
+    config.mcpServers = mcpServers;
   }
 
   return config;

--- a/src/adapters/copilot.ts
+++ b/src/adapters/copilot.ts
@@ -3,7 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
-import { buildComplianceSection } from './shared.js';
+import { buildComplianceSection, buildMcpServersMarkdown } from './shared.js';
 
 /**
  * Export a gitagent to GitHub Copilot CLI format.
@@ -143,6 +143,12 @@ function buildAgentMd(
         }
       }
     }
+  }
+
+  // MCP servers
+  const mcpSection = buildMcpServersMarkdown(manifest.mcp_servers);
+  if (mcpSection) {
+    parts.push(mcpSection);
   }
 
   // Compliance constraints

--- a/src/adapters/crewai.ts
+++ b/src/adapters/crewai.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills } from '../utils/skill-loader.js';
+import { buildMcpServersMarkdown } from './shared.js';
 
 export function exportToCrewAI(dir: string): string {
   const agentDir = resolve(dir);
@@ -30,6 +31,12 @@ export function exportToCrewAI(dir: string): string {
       .map(s => `- ${s.frontmatter.name}: ${s.frontmatter.description}`)
       .join('\n');
     backstory += `\n\nCapabilities (Skills):\n${skillDescriptions}`;
+  }
+
+  // MCP servers
+  const mcpSection = buildMcpServersMarkdown(manifest.mcp_servers);
+  if (mcpSection) {
+    backstory += `\n\n${mcpSection}`;
   }
 
   // Build CrewAI YAML config

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -3,6 +3,7 @@ import { join, resolve, basename } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
+import { buildMcpServersConfig } from './shared.js';
 
 /**
  * Export a gitagent to Cursor rules format.
@@ -28,6 +29,8 @@ export interface CursorRule {
 
 export interface CursorExport {
   rules: CursorRule[];
+  /** Content for .cursor/mcp.json (null if no MCP servers defined) */
+  mcpConfig: Record<string, unknown> | null;
 }
 
 export function exportToCursor(dir: string): CursorExport {
@@ -49,7 +52,11 @@ export function exportToCursor(dir: string): CursorExport {
     rules.push(buildSkillRule(skill));
   }
 
-  return { rules };
+  // MCP servers
+  const mcpServers = buildMcpServersConfig(manifest.mcp_servers);
+  const mcpConfig = mcpServers ? { mcpServers } : null;
+
+  return { rules, mcpConfig };
 }
 
 /**
@@ -63,6 +70,12 @@ export function exportToCursorString(dir: string): string {
   for (const rule of exp.rules) {
     parts.push(`# === .cursor/rules/${rule.filename} ===`);
     parts.push(rule.content);
+    parts.push('');
+  }
+
+  if (exp.mcpConfig) {
+    parts.push('# === .cursor/mcp.json ===');
+    parts.push(JSON.stringify(exp.mcpConfig, null, 2));
     parts.push('');
   }
 

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -3,7 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
-import { buildComplianceSection } from './shared.js';
+import { buildComplianceSection, buildMcpServersConfig } from './shared.js';
 
 /**
  * Export a gitagent to Google Gemini CLI format.
@@ -244,8 +244,9 @@ function buildSettings(
     settings.hooks = hooksConfig;
   }
 
-  // MCP servers (placeholder - requires manual configuration)
-  settings.mcpServers = {};
+  // MCP servers
+  const mcpServers = buildMcpServersConfig(manifest.mcp_servers);
+  settings.mcpServers = mcpServers ?? {};
 
   return settings;
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,5 +1,5 @@
 export { exportToSystemPrompt } from './system-prompt.js';
-export { exportToClaudeCode } from './claude-code.js';
+export { exportToClaudeCode, exportToClaudeCodeString } from './claude-code.js';
 export { exportToOpenAI } from './openai.js';
 export { exportToCrewAI } from './crewai.js';
 export { exportToOpenClawString, exportToOpenClaw } from './openclaw.js';

--- a/src/adapters/lyzr.ts
+++ b/src/adapters/lyzr.ts
@@ -1,6 +1,7 @@
 import { resolve, join } from 'node:path';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
+import { buildMcpServersMarkdown } from './shared.js';
 
 export interface LyzrAgentPayload {
   name: string;
@@ -65,6 +66,10 @@ function buildAgentInstructions(agentDir: string): string {
     const toolsNote = tools.length > 0 ? `\nAllowed tools: ${tools.join(', ')}` : '';
     parts.push(`## Skill: ${skill.frontmatter.name}\n${skill.frontmatter.description}${toolsNote}\n\n${skill.instructions}`);
   }
+
+  // MCP servers
+  const mcpSection = buildMcpServersMarkdown(manifest.mcp_servers);
+  if (mcpSection) parts.push(mcpSection);
 
   // Compliance constraints
   if (manifest.compliance) {

--- a/src/adapters/mcp-servers.test.ts
+++ b/src/adapters/mcp-servers.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for MCP server definitions in agent.yaml exports.
+ *
+ * Uses Node.js built-in test runner (node --test).
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { buildMcpServersConfig, buildMcpServersMarkdown } from './shared.js';
+import { exportToCodex } from './codex.js';
+import { exportToClaudeCode } from './claude-code.js';
+import { exportToCursor } from './cursor.js';
+import { exportToGemini } from './gemini.js';
+import { exportToOpenCode } from './opencode.js';
+import { exportToSystemPrompt } from './system-prompt.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STDIO_SERVER = {
+  command: 'npx',
+  args: ['-y', '@modelcontextprotocol/server-postgres'],
+  env: { DATABASE_URL: '${DATABASE_URL}' },
+};
+
+const HTTP_SERVER = {
+  url: 'https://mcp.example.com/sse',
+  headers: { Authorization: 'Bearer ${MCP_TOKEN}' },
+};
+
+function makeAgentDir(opts: {
+  name?: string;
+  mcpServers?: Record<string, unknown>;
+}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gitagent-mcp-test-'));
+
+  const mcpBlock = opts.mcpServers
+    ? `mcp_servers:\n${Object.entries(opts.mcpServers)
+        .map(([name, config]) => {
+          const c = config as Record<string, unknown>;
+          let block = `  ${name}:\n`;
+          if (c.command) block += `    command: ${c.command}\n`;
+          if (c.args) block += `    args:\n${(c.args as string[]).map(a => `      - '${a}'`).join('\n')}\n`;
+          if (c.env) {
+            block += `    env:\n`;
+            for (const [k, v] of Object.entries(c.env as Record<string, string>)) {
+              block += `      ${k}: '${v}'\n`;
+            }
+          }
+          if (c.url) block += `    url: '${c.url}'\n`;
+          if (c.headers) {
+            block += `    headers:\n`;
+            for (const [k, v] of Object.entries(c.headers as Record<string, string>)) {
+              block += `      ${k}: '${v}'\n`;
+            }
+          }
+          return block;
+        })
+        .join('')}`
+    : '';
+
+  writeFileSync(
+    join(dir, 'agent.yaml'),
+    `spec_version: '0.1.0'\nname: ${opts.name ?? 'test-agent'}\nversion: '0.1.0'\ndescription: 'A test agent'\n${mcpBlock}`,
+    'utf-8',
+  );
+
+  writeFileSync(join(dir, 'SOUL.md'), '# Test Agent\nA test agent soul.', 'utf-8');
+
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// buildMcpServersConfig
+// ---------------------------------------------------------------------------
+
+describe('buildMcpServersConfig', () => {
+  test('returns null for undefined input', () => {
+    assert.equal(buildMcpServersConfig(undefined), null);
+  });
+
+  test('returns null for empty object', () => {
+    assert.equal(buildMcpServersConfig({}), null);
+  });
+
+  test('maps stdio server correctly', () => {
+    const result = buildMcpServersConfig({ 'my-db': STDIO_SERVER });
+    assert.ok(result);
+    const entry = result['my-db'] as Record<string, unknown>;
+    assert.equal(entry.command, 'npx');
+    assert.deepEqual(entry.args, ['-y', '@modelcontextprotocol/server-postgres']);
+    assert.deepEqual(entry.env, { DATABASE_URL: '${DATABASE_URL}' });
+    assert.equal(entry.url, undefined);
+  });
+
+  test('maps HTTP server correctly', () => {
+    const result = buildMcpServersConfig({ remote: HTTP_SERVER });
+    assert.ok(result);
+    const entry = result['remote'] as Record<string, unknown>;
+    assert.equal(entry.url, 'https://mcp.example.com/sse');
+    assert.deepEqual(entry.headers, { Authorization: 'Bearer ${MCP_TOKEN}' });
+    assert.equal(entry.command, undefined);
+  });
+
+  test('handles multiple servers', () => {
+    const result = buildMcpServersConfig({
+      db: STDIO_SERVER,
+      remote: HTTP_SERVER,
+    });
+    assert.ok(result);
+    assert.ok(result['db']);
+    assert.ok(result['remote']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildMcpServersMarkdown
+// ---------------------------------------------------------------------------
+
+describe('buildMcpServersMarkdown', () => {
+  test('returns empty string for undefined input', () => {
+    assert.equal(buildMcpServersMarkdown(undefined), '');
+  });
+
+  test('returns empty string for empty object', () => {
+    assert.equal(buildMcpServersMarkdown({}), '');
+  });
+
+  test('includes server name and type for stdio server', () => {
+    const result = buildMcpServersMarkdown({ 'my-db': STDIO_SERVER });
+    assert.match(result, /### my-db/);
+    assert.match(result, /Type: stdio/);
+    assert.match(result, /npx/);
+  });
+
+  test('includes server name and type for HTTP server', () => {
+    const result = buildMcpServersMarkdown({ remote: HTTP_SERVER });
+    assert.match(result, /### remote/);
+    assert.match(result, /Type: HTTP/);
+    assert.match(result, /mcp\.example\.com/);
+  });
+
+  test('includes environment variable names', () => {
+    const result = buildMcpServersMarkdown({ db: STDIO_SERVER });
+    assert.match(result, /DATABASE_URL/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 1 adapter integration tests
+// ---------------------------------------------------------------------------
+
+describe('Tier 1 adapters: MCP config in structured output', () => {
+  test('Codex: mcpServers in config when mcp_servers defined', () => {
+    const dir = makeAgentDir({ mcpServers: { db: STDIO_SERVER } });
+    const { config } = exportToCodex(dir);
+    assert.ok(config.mcpServers);
+    const servers = config.mcpServers as Record<string, Record<string, unknown>>;
+    assert.equal(servers.db.command, 'npx');
+  });
+
+  test('Codex: no mcpServers in config when mcp_servers absent', () => {
+    const dir = makeAgentDir({});
+    const { config } = exportToCodex(dir);
+    assert.equal(config.mcpServers, undefined);
+  });
+
+  test('Claude Code: mcpConfig populated when mcp_servers defined', () => {
+    const dir = makeAgentDir({ mcpServers: { remote: HTTP_SERVER } });
+    const result = exportToClaudeCode(dir);
+    assert.ok(result.mcpConfig);
+    const servers = (result.mcpConfig as Record<string, unknown>).mcpServers as Record<string, Record<string, unknown>>;
+    assert.equal(servers.remote.url, 'https://mcp.example.com/sse');
+  });
+
+  test('Claude Code: mcpConfig is null when mcp_servers absent', () => {
+    const dir = makeAgentDir({});
+    const result = exportToClaudeCode(dir);
+    assert.equal(result.mcpConfig, null);
+  });
+
+  test('Cursor: mcpConfig populated when mcp_servers defined', () => {
+    const dir = makeAgentDir({ mcpServers: { db: STDIO_SERVER } });
+    const result = exportToCursor(dir);
+    assert.ok(result.mcpConfig);
+    const servers = (result.mcpConfig as Record<string, unknown>).mcpServers as Record<string, Record<string, unknown>>;
+    assert.equal(servers.db.command, 'npx');
+  });
+
+  test('Cursor: mcpConfig is null when mcp_servers absent', () => {
+    const dir = makeAgentDir({});
+    const result = exportToCursor(dir);
+    assert.equal(result.mcpConfig, null);
+  });
+
+  test('Gemini: settings.mcpServers populated when mcp_servers defined', () => {
+    const dir = makeAgentDir({ mcpServers: { db: STDIO_SERVER } });
+    const { settings } = exportToGemini(dir);
+    const servers = settings.mcpServers as Record<string, Record<string, unknown>>;
+    assert.equal(servers.db.command, 'npx');
+  });
+
+  test('Gemini: settings.mcpServers is empty object when mcp_servers absent', () => {
+    const dir = makeAgentDir({});
+    const { settings } = exportToGemini(dir);
+    assert.deepEqual(settings.mcpServers, {});
+  });
+
+  test('OpenCode: mcpServers in config when mcp_servers defined', () => {
+    const dir = makeAgentDir({ mcpServers: { remote: HTTP_SERVER } });
+    const { config } = exportToOpenCode(dir);
+    assert.ok(config.mcpServers);
+    const servers = config.mcpServers as Record<string, Record<string, unknown>>;
+    assert.equal(servers.remote.url, 'https://mcp.example.com/sse');
+  });
+
+  test('OpenCode: no mcpServers in config when mcp_servers absent', () => {
+    const dir = makeAgentDir({});
+    const { config } = exportToOpenCode(dir);
+    assert.equal(config.mcpServers, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2 adapter integration tests
+// ---------------------------------------------------------------------------
+
+describe('Tier 2 adapters: MCP servers in markdown output', () => {
+  test('system-prompt includes MCP section when mcp_servers defined', () => {
+    const dir = makeAgentDir({ mcpServers: { db: STDIO_SERVER } });
+    const result = exportToSystemPrompt(dir);
+    assert.match(result, /MCP Servers/);
+    assert.match(result, /my-db|db/);
+  });
+
+  test('system-prompt omits MCP section when mcp_servers absent', () => {
+    const dir = makeAgentDir({});
+    const result = exportToSystemPrompt(dir);
+    assert.ok(!result.includes('MCP Servers'));
+  });
+});

--- a/src/adapters/nanobot.ts
+++ b/src/adapters/nanobot.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
+import { buildMcpServersMarkdown } from './shared.js';
 
 /**
  * Export a gitagent to Nanobot format.
@@ -150,6 +151,12 @@ function buildSystemPrompt(agentDir: string, manifest: ReturnType<typeof loadAge
       }
       parts.push(toolParts.join('\n'));
     }
+  }
+
+  // MCP servers
+  const mcpSection = buildMcpServersMarkdown(manifest.mcp_servers);
+  if (mcpSection) {
+    parts.push(mcpSection);
   }
 
   // Compliance constraints

--- a/src/adapters/openai.ts
+++ b/src/adapters/openai.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
+import { buildMcpServersMarkdown } from './shared.js';
 
 export function exportToOpenAI(dir: string): string {
   const agentDir = resolve(dir);
@@ -80,6 +81,10 @@ function buildSystemPrompt(agentDir: string, manifest: ReturnType<typeof loadAge
       parts.push(`## OpenAI Agent Configuration\n${yaml.dump(openaiConfig)}`);
     }
   }
+
+  // MCP servers
+  const mcpSection = buildMcpServersMarkdown(manifest.mcp_servers);
+  if (mcpSection) parts.push(mcpSection);
 
   if (manifest.compliance) {
     const c = manifest.compliance;

--- a/src/adapters/openclaw.ts
+++ b/src/adapters/openclaw.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
+import { buildMcpServersMarkdown } from './shared.js';
 
 /**
  * Export a gitagent to OpenClaw workspace format.
@@ -227,6 +228,12 @@ function buildAgentsMd(agentDir: string, manifest: ReturnType<typeof loadAgentMa
         }
       }
     }
+  }
+
+  // MCP servers
+  const mcpSection = buildMcpServersMarkdown(manifest.mcp_servers);
+  if (mcpSection) {
+    parts.push(`\n${mcpSection}`);
   }
 
   // Compliance constraints

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -3,7 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
-import { buildComplianceSection } from './shared.js';
+import { buildComplianceSection, buildMcpServersConfig } from './shared.js';
 
 /**
  * Export a gitagent to OpenCode format.
@@ -184,6 +184,12 @@ function buildConfig(manifest: ReturnType<typeof loadAgentManifest>): Record<str
         npm: getNpmPackage(provider),
       },
     };
+  }
+
+  // MCP servers
+  const mcpServers = buildMcpServersConfig(manifest.mcp_servers);
+  if (mcpServers) {
+    config.mcpServers = mcpServers;
   }
 
   return config;

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -1,4 +1,4 @@
-import { loadAgentManifest } from '../utils/loader.js';
+import { loadAgentManifest, type AgentManifest } from '../utils/loader.js';
 
 /**
  * Build a markdown compliance constraints section from a gitagent manifest.
@@ -65,4 +65,61 @@ export function buildComplianceSection(compliance: NonNullable<ReturnType<typeof
 
   if (constraints.length === 0) return '';
   return `## Compliance Constraints\n\n${constraints.join('\n')}`;
+}
+
+/**
+ * Convert agent.yaml mcp_servers to the standard mcpServers JSON format
+ * used by Claude Code, Cursor, Gemini, Codex, and OpenCode.
+ */
+export function buildMcpServersConfig(
+  mcpServers?: AgentManifest['mcp_servers'],
+): Record<string, unknown> | null {
+  if (!mcpServers || Object.keys(mcpServers).length === 0) return null;
+
+  const result: Record<string, unknown> = {};
+  for (const [name, config] of Object.entries(mcpServers)) {
+    const entry: Record<string, unknown> = {};
+    if (config.command) {
+      entry.command = config.command;
+      if (config.args) entry.args = config.args;
+    }
+    if (config.url) {
+      entry.url = config.url;
+      if (config.headers) entry.headers = config.headers;
+    }
+    if (config.env) entry.env = config.env;
+    result[name] = entry;
+  }
+  return result;
+}
+
+/**
+ * Build a markdown documentation section for MCP servers.
+ * Used by adapters without native MCP config support.
+ */
+export function buildMcpServersMarkdown(
+  mcpServers?: AgentManifest['mcp_servers'],
+): string {
+  if (!mcpServers || Object.keys(mcpServers).length === 0) return '';
+
+  const parts: string[] = ['## MCP Servers\n'];
+  for (const [name, config] of Object.entries(mcpServers)) {
+    parts.push(`### ${name}`);
+    if (config.command) {
+      const cmd = config.args
+        ? `${config.command} ${config.args.join(' ')}`
+        : config.command;
+      parts.push(`- Type: stdio`);
+      parts.push(`- Command: \`${cmd}\``);
+    }
+    if (config.url) {
+      parts.push(`- Type: HTTP`);
+      parts.push(`- URL: ${config.url}`);
+    }
+    if (config.env && Object.keys(config.env).length > 0) {
+      parts.push(`- Environment: ${Object.keys(config.env).join(', ')}`);
+    }
+    parts.push('');
+  }
+  return parts.join('\n');
 }

--- a/src/adapters/system-prompt.ts
+++ b/src/adapters/system-prompt.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'node:path';
 import yaml from 'js-yaml';
 import { loadAgentManifest, loadFileIfExists } from '../utils/loader.js';
 import { loadAllSkills, getAllowedTools } from '../utils/skill-loader.js';
+import { buildMcpServersMarkdown } from './shared.js';
 
 export function exportToSystemPrompt(dir: string): string {
   const agentDir = resolve(dir);
@@ -57,6 +58,12 @@ export function exportToSystemPrompt(dir: string): string {
         }
       }
     }
+  }
+
+  // MCP servers
+  const mcpSection = buildMcpServersMarkdown(manifest.mcp_servers);
+  if (mcpSection) {
+    parts.push(mcpSection);
   }
 
   // Compliance constraints as system instructions

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { error, heading, info, success } from '../utils/format.js';
 import {
   exportToSystemPrompt,
-  exportToClaudeCode,
+  exportToClaudeCodeString,
   exportToOpenAI,
   exportToCrewAI,
   exportToOpenClawString,
@@ -44,7 +44,7 @@ export const exportCommand = new Command('export')
           result = exportToSystemPrompt(dir);
           break;
         case 'claude-code':
-          result = exportToClaudeCode(dir);
+          result = exportToClaudeCodeString(dir);
           break;
         case 'openai':
           result = exportToOpenAI(dir);

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -62,6 +62,13 @@ export interface AgentManifest {
     protocols?: string[];
   };
   compliance?: ComplianceConfig;
+  mcp_servers?: Record<string, {
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    url?: string;
+    headers?: Record<string, string>;
+  }>;
   tags?: string[];
   metadata?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

- Adds `mcp_servers` field to `agent.yaml` so MCP servers can be defined once and exported to each provider's native configuration format
- Supports both stdio-based servers (`command` + `args`) and HTTP-based servers (`url` + `headers`)
- Tier 1 adapters export native MCP config JSON: Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), Gemini (`.gemini/settings.json`), Codex (`codex.json`), OpenCode (`opencode.json`)
- Tier 2 adapters document MCP servers in markdown instructions: system-prompt, copilot, openai, crewai, lyzr, nanobot, openclaw
- Fixes pre-existing duplicate `.requiredOption` bugs in export/import commands

Closes #57

## Test plan

- [x] 51 tests pass (20 new MCP-specific tests + 31 existing)
- [x] TypeScript builds cleanly
- [x] `gitagent validate` passes on updated `examples/full/agent.yaml`
- [ ] Manual: export with `mcp_servers` defined for each format, verify output contains correct MCP config

🤖 Generated with [Claude Code](https://claude.com/claude-code)