### PR TITLE
docs: fix scoped npm package references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,4 @@ Closes #
 - [ ] My code follows the existing style of this project
 - [ ] I have added/updated tests (if applicable)
 - [ ] I have updated documentation (if applicable)
-- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] I have read the [CONTRIBUTING.md](https://github.com/open-gitagent/gitagent/blob/main/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # gitagent | your repository becomes your agent
 
-[![npm version](https://img.shields.io/npm/v/@shreyaskapale/gitagent)](https://www.npmjs.com/package/@shreyaskapale/gitagent)
+[![npm version](https://img.shields.io/npm/v/@open-gitagent/gitagent)](https://www.npmjs.com/package/@open-gitagent/gitagent)
 [![CI](https://github.com/open-gitagent/gitagent/actions/workflows/ci.yml/badge.svg)](https://github.com/open-gitagent/gitagent/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Spec: v0.1.0](https://img.shields.io/badge/spec-v0.1.0-blue)](https://github.com/open-gitagent/gitagent/blob/main/spec/SPECIFICATION.md)

--- a/docs.md
+++ b/docs.md
@@ -48,7 +48,7 @@ A framework-agnostic, git-native standard for defining AI agents.
 ## Installation
 
 ```bash
-npm install -g gitagent
+npm install -g @open-gitagent/gitagent
 ```
 
 Verify:

--- a/examples/gitagent-helper/skills/get-started/SKILL.md
+++ b/examples/gitagent-helper/skills/get-started/SKILL.md
@@ -17,7 +17,7 @@ When a user is new to gitagent, wants to set up their first agent, or asks "how 
 
 ### Installation
 ```bash
-npm install -g gitagent
+npm install -g @open-gitagent/gitagent
 gitagent --version
 ```
 


### PR DESCRIPTION
## What
Update the remaining docs that reference the old/unscoped npm package name.

Changes in this PR:
- update the README npm badge/link to `@open-gitagent/gitagent`
- update `docs.md` installation command to `npm install -g @open-gitagent/gitagent`
- update `examples/gitagent-helper/skills/get-started/SKILL.md` installation command to `npm install -g @open-gitagent/gitagent`

## Why
The repo still had a few references to the old package name / old npm link, while the published package is `@open-gitagent/gitagent`.

Closes #

## How Tested
- [x] `npm run build` passes
- [x] `gitagent validate` passes on example agents
- [x] Manual testing (describe below)

Manual testing:
- `node dist/index.js validate -d ./examples/standard`
- `node dist/index.js --help`

## Checklist
- [x] My code follows the existing style of this project
- [ ] I have added/updated tests (if applicable)
- [x] I have updated documentation (if applicable)
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
