### PR TITLE
docs: rename gitagent CLI command references to gapman

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ A clear and concise description of the bug.
 ## Environment
 - **OS**: (e.g., macOS 14, Ubuntu 22.04, Windows 11)
 - **Node.js version**: (e.g., 18.19.0)
-- **gitagent version**: (run `gitagent --version`)
+- **gapman version**: (run `gapman --version`)
 - **Adapter** (if applicable): (e.g., claude-code, openai, crewai)
 
 ## Steps to Reproduce

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,16 +55,16 @@ Recompiles on file changes. You still need to re-run the command manually.
 src/
 ├── index.ts              # CLI entry point (Commander.js)
 ├── commands/             # One file per CLI command
-│   ├── run.ts            # gitagent run
-│   ├── init.ts           # gitagent init
-│   ├── validate.ts       # gitagent validate
-│   ├── export.ts         # gitagent export
-│   ├── import.ts         # gitagent import
-│   ├── audit.ts          # gitagent audit
-│   ├── skills.ts         # gitagent skills
-│   ├── install.ts        # gitagent install
-│   ├── info.ts           # gitagent info
-│   └── lyzr.ts           # gitagent lyzr
+│   ├── run.ts            # gapman run
+│   ├── init.ts           # gapman init
+│   ├── validate.ts       # gapman validate
+│   ├── export.ts         # gapman export
+│   ├── import.ts         # gapman import
+│   ├── audit.ts          # gapman audit
+│   ├── skills.ts         # gapman skills
+│   ├── install.ts        # gapman install
+│   ├── info.ts           # gapman info
+│   └── lyzr.ts           # gapman lyzr
 ├── runners/              # Runtime adapters (execute agents)
 │   ├── claude.ts         # Claude Code runner
 │   ├── openai.ts         # OpenAI Agents SDK runner

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Fork any public agent repo, customize its `SOUL.md`, add your own skills, and PR
 <img src="patterns/agent-forking.png" alt="Agent Forking & Remixing" width="600" />
 
 ### CI/CD for Agents
-Run `gitagent validate` on every push via GitHub Actions. Test agent behavior in CI, block bad merges, and auto-deploy — treat agent quality like code quality.
+Run `gapman validate` on every push via GitHub Actions. Test agent behavior in CI, block bad merges, and auto-deploy — treat agent quality like code quality.
 
 <img src="patterns/ci-cd-agents.png" alt="CI/CD for Agents" width="600" />
 
@@ -216,7 +216,7 @@ This pattern is demonstrated with [NVIDIA's AIQ Deep Researcher](https://github.
 
 - **Fork for a new domain** — edit `SOUL.md` for legal/medical/finance research without touching Python
 - **Version prompts independently** — `git diff` when the orchestrator's style regresses
-- **Validate SOD** — `gitagent validate --compliance` ensures the orchestrator can't also be the researcher
+- **Validate SOD** — `gapman validate --compliance` ensures the orchestrator can't also be the researcher
 - **Export to other runtimes** — same identity on Claude Code, OpenAI, or as a raw system prompt
 
 ```
@@ -347,7 +347,7 @@ gitagent has first-class support for financial regulatory compliance:
 
 Inspired by [Salient AI](https://www.trysalient.com/)'s purpose-built agent architecture and the [FINOS AI Governance Framework](https://air-governance-framework.finos.org/mitigations/mi-22_multi-agent-isolation-and-segmentation.html).
 
-Run `gitagent audit` for a full compliance checklist against your agent configuration.
+Run `gapman audit` for a full compliance checklist against your agent configuration.
 
 ## Adapters
 

--- a/docs.md
+++ b/docs.md
@@ -60,7 +60,7 @@ gapman --version   # 0.3.1
 gapman --help
 
 # gitagent alias also works
-gitagent --version
+gapman --version
 ```
 
 ---
@@ -69,28 +69,28 @@ gitagent --version
 
 ```bash
 # Create a new agent
-gitagent init --template standard --dir ./my-agent
+gapman init --template standard --dir ./my-agent
 
 # Validate it
-gitagent validate -d ./my-agent
+gapman validate -d ./my-agent
 
 # Run it locally with Claude Code
-gitagent run -d ./my-agent
+gapman run -d ./my-agent
 
 # Run from a git repo
-gitagent run -r https://github.com/user/my-agent -p "Hello"
+gapman run -r https://github.com/user/my-agent -p "Hello"
 
 # Run with a different adapter
-gitagent run -d ./my-agent -a github -p "Summarize this project"
+gapman run -d ./my-agent -a github -p "Summarize this project"
 
 # Clone + auto-detect best adapter + run
-gitagent run -r https://github.com/user/my-agent -a git -p "Hello"
+gapman run -r https://github.com/user/my-agent -a git -p "Hello"
 
 # Deploy to Lyzr Studio and chat
-gitagent lyzr run -r https://github.com/user/my-agent -p "Hello"
+gapman lyzr run -r https://github.com/user/my-agent -p "Hello"
 
 # Export to another framework
-gitagent export -f openai -d ./my-agent -o agent.py
+gapman export -f openai -d ./my-agent -o agent.py
 ```
 
 ---
@@ -336,7 +336,7 @@ metadata:
 Scaffold a new agent repository.
 
 ```bash
-gitagent init [options]
+gapman init [options]
 ```
 
 | Option | Default | Description |
@@ -353,8 +353,8 @@ gitagent init [options]
 | `full` | Everything in standard + `memory/`, `hooks/`, `examples/`, `agents/`, `compliance/`, `config/`, `.gitignore` |
 
 ```bash
-gitagent init --template minimal
-gitagent init --template full --dir ./my-agent
+gapman init --template minimal
+gapman init --template full --dir ./my-agent
 ```
 
 ---
@@ -364,7 +364,7 @@ gitagent init --template full --dir ./my-agent
 Validate an agent against the specification and optionally check regulatory compliance.
 
 ```bash
-gitagent validate [options]
+gapman validate [options]
 ```
 
 | Option | Default | Description |
@@ -392,9 +392,9 @@ gitagent validate [options]
 - Vendor management metadata for dependencies
 
 ```bash
-gitagent validate
-gitagent validate --compliance
-gitagent validate -d ./examples/full --compliance
+gapman validate
+gapman validate --compliance
+gapman validate -d ./examples/full --compliance
 ```
 
 ---
@@ -404,7 +404,7 @@ gitagent validate -d ./examples/full --compliance
 Display a formatted summary of the agent configuration.
 
 ```bash
-gitagent info [options]
+gapman info [options]
 ```
 
 | Option | Default | Description |
@@ -414,8 +414,8 @@ gitagent info [options]
 Shows: name, version, description, author, license, model preferences, skills, tools, sub-agents, runtime config, compliance settings, tags, and a SOUL.md preview.
 
 ```bash
-gitagent info
-gitagent info -d ./examples/standard
+gapman info
+gapman info -d ./examples/standard
 ```
 
 ---
@@ -425,7 +425,7 @@ gitagent info -d ./examples/standard
 Export an agent to another framework's format.
 
 ```bash
-gitagent export [options]
+gapman export [options]
 ```
 
 | Option | Default | Description |
@@ -449,22 +449,22 @@ gitagent export [options]
 
 ```bash
 # Print system prompt to terminal
-gitagent export --format system-prompt
+gapman export --format system-prompt
 
 # Save Claude Code format to file
-gitagent export --format claude-code --output CLAUDE.md
+gapman export --format claude-code --output CLAUDE.md
 
 # Generate OpenAI Python code
-gitagent export --format openai --output agent.py
+gapman export --format openai --output agent.py
 
 # Preview Lyzr API payload
-gitagent export --format lyzr -d ./examples/lyzr-agent
+gapman export --format lyzr -d ./examples/lyzr-agent
 
 # Preview GitHub Models payload
-gitagent export --format github -d ./examples/standard
+gapman export --format github -d ./examples/standard
 
 # Export CrewAI config
-gitagent export --format crewai -d ./examples/standard
+gapman export --format crewai -d ./examples/standard
 ```
 
 ---
@@ -474,7 +474,7 @@ gitagent export --format crewai -d ./examples/standard
 Import from another agent framework into gitagent format.
 
 ```bash
-gitagent import --from <format> <path> [options]
+gapman import --from <format> <path> [options]
 ```
 
 | Option | Default | Description |
@@ -492,9 +492,9 @@ gitagent import --from <format> <path> [options]
 | `crewai` | CrewAI YAML config | `agent.yaml`, `SOUL.md`, sub-agents in `agents/` |
 
 ```bash
-gitagent import --from claude ./my-claude-project
-gitagent import --from cursor ./.cursorrules
-gitagent import --from crewai ./crew.yaml --dir ./imported-agent
+gapman import --from claude ./my-claude-project
+gapman import --from cursor ./.cursorrules
+gapman import --from crewai ./crew.yaml --dir ./imported-agent
 ```
 
 ---
@@ -504,7 +504,7 @@ gitagent import --from crewai ./crew.yaml --dir ./imported-agent
 Resolve and install git-based agent dependencies declared in `agent.yaml`.
 
 ```bash
-gitagent install [options]
+gapman install [options]
 ```
 
 | Option | Default | Description |
@@ -518,8 +518,8 @@ For each entry in `dependencies`:
 - Validates that installed dependencies contain `agent.yaml`
 
 ```bash
-gitagent install
-gitagent install -d ./my-agent
+gapman install
+gapman install -d ./my-agent
 ```
 
 ---
@@ -529,7 +529,7 @@ gitagent install -d ./my-agent
 Generate a comprehensive compliance audit report.
 
 ```bash
-gitagent audit [options]
+gapman audit [options]
 ```
 
 | Option | Default | Description |
@@ -549,8 +549,8 @@ gitagent audit [options]
 9. **Audit Hooks** — hooks.yaml and compliance-flagged hooks
 
 ```bash
-gitagent audit
-gitagent audit -d ./examples/full
+gapman audit
+gapman audit -d ./examples/full
 ```
 
 ---
@@ -562,7 +562,7 @@ Manage agent skills — search registries, install, list, and inspect.
 #### skills search
 
 ```bash
-gitagent skills search <query> [options]
+gapman skills search <query> [options]
 ```
 
 | Option | Default | Description |
@@ -574,7 +574,7 @@ gitagent skills search <query> [options]
 #### skills install
 
 ```bash
-gitagent skills install <name> [options]
+gapman skills install <name> [options]
 ```
 
 | Option | Default | Description |
@@ -588,7 +588,7 @@ gitagent skills install <name> [options]
 #### skills list
 
 ```bash
-gitagent skills list [options]
+gapman skills list [options]
 ```
 
 | Option | Default | Description |
@@ -599,7 +599,7 @@ gitagent skills list [options]
 #### skills info
 
 ```bash
-gitagent skills info <name> [options]
+gapman skills info <name> [options]
 ```
 
 | Option | Default | Description |
@@ -607,10 +607,10 @@ gitagent skills info <name> [options]
 | `-d, --dir <dir>` | `.` | Agent directory |
 
 ```bash
-gitagent skills search "code review"
-gitagent skills install code-review --global
-gitagent skills list
-gitagent skills info code-review
+gapman skills search "code review"
+gapman skills install code-review --global
+gapman skills list
+gapman skills info code-review
 ```
 
 ---
@@ -620,7 +620,7 @@ gitagent skills info code-review
 Run an agent interactively with a specific adapter/framework.
 
 ```bash
-gitagent run [options]
+gapman run [options]
 ```
 
 | Option | Default | Description |
@@ -654,31 +654,31 @@ Either `--repo` or `--dir` is required.
 
 ```bash
 # Run a local agent with Claude Code (interactive)
-gitagent run -d ./my-agent
+gapman run -d ./my-agent
 
 # Run from a git repo
-gitagent run -r https://github.com/user/agent
+gapman run -r https://github.com/user/agent
 
 # Run with GitHub Models
-gitagent run -d ./my-agent -a github -p "Review my code"
+gapman run -d ./my-agent -a github -p "Review my code"
 
 # Run with Lyzr
-gitagent run -r https://github.com/user/agent -a lyzr -p "Hello"
+gapman run -r https://github.com/user/agent -a lyzr -p "Hello"
 
 # Auto-detect adapter from repo contents
-gitagent run -r https://github.com/user/agent -a git -p "Hello"
+gapman run -r https://github.com/user/agent -a git -p "Hello"
 
 # One-shot prompt mode
-gitagent run -d ./my-agent -p "Review my authentication code"
+gapman run -d ./my-agent -p "Review my authentication code"
 
 # Run an agent definition against a separate target workspace
-gitagent run -d ./agents/reviewer --workspace ~/code/my-app -a claude -p "Review this repository"
+gapman run -d ./agents/reviewer --workspace ~/code/my-app -a claude -p "Review this repository"
 
 # Run a specific branch, force refresh
-gitagent run -r https://github.com/user/agent -b develop --refresh
+gapman run -r https://github.com/user/agent -b develop --refresh
 
 # Just output the system prompt (no runner)
-gitagent run -d ./my-agent -a prompt
+gapman run -d ./my-agent -a prompt
 ```
 
 ---
@@ -688,7 +688,7 @@ gitagent run -d ./my-agent -a prompt
 Manage Lyzr Studio agents — create, update, inspect, and run.
 
 ```bash
-gitagent lyzr <subcommand> [options]
+gapman lyzr <subcommand> [options]
 ```
 
 #### lyzr create
@@ -696,7 +696,7 @@ gitagent lyzr <subcommand> [options]
 Create a new agent on Lyzr Studio from the local gitagent definition.
 
 ```bash
-gitagent lyzr create [options]
+gapman lyzr create [options]
 ```
 
 | Option | Default | Description |
@@ -707,7 +707,7 @@ gitagent lyzr create [options]
 Saves the returned agent ID to `.lyzr_agent_id` for reuse.
 
 ```bash
-gitagent lyzr create -d ./examples/lyzr-agent
+gapman lyzr create -d ./examples/lyzr-agent
 ```
 
 #### lyzr update
@@ -715,7 +715,7 @@ gitagent lyzr create -d ./examples/lyzr-agent
 Push the current gitagent definition to an existing Lyzr agent.
 
 ```bash
-gitagent lyzr update [options]
+gapman lyzr update [options]
 ```
 
 | Option | Default | Description |
@@ -725,8 +725,8 @@ gitagent lyzr update [options]
 | `--api-key <key>` | — | Lyzr API key (or set `LYZR_API_KEY`) |
 
 ```bash
-gitagent lyzr update -d ./examples/lyzr-agent
-gitagent lyzr update --agent-id abc123
+gapman lyzr update -d ./examples/lyzr-agent
+gapman lyzr update --agent-id abc123
 ```
 
 #### lyzr info
@@ -734,7 +734,7 @@ gitagent lyzr update --agent-id abc123
 Show the Lyzr agent ID linked to this gitagent directory.
 
 ```bash
-gitagent lyzr info [options]
+gapman lyzr info [options]
 ```
 
 | Option | Default | Description |
@@ -742,7 +742,7 @@ gitagent lyzr info [options]
 | `-d, --dir <dir>` | `.` | Agent directory |
 
 ```bash
-gitagent lyzr info -d ./examples/lyzr-agent
+gapman lyzr info -d ./examples/lyzr-agent
 ```
 
 #### lyzr run
@@ -750,7 +750,7 @@ gitagent lyzr info -d ./examples/lyzr-agent
 Clone a git agent repo, create it on Lyzr, and chat — all in one command.
 
 ```bash
-gitagent lyzr run [options]
+gapman lyzr run [options]
 ```
 
 | Option | Default | Description |
@@ -767,13 +767,13 @@ If no `.lyzr_agent_id` exists, the agent is created on Lyzr Studio first. If no 
 
 ```bash
 # Full one-liner: clone + create + chat
-gitagent lyzr run -r https://github.com/user/my-agent -p "Hello"
+gapman lyzr run -r https://github.com/user/my-agent -p "Hello"
 
 # From local directory
-gitagent lyzr run -d ./examples/lyzr-agent -p "Summarize AI trends"
+gapman lyzr run -d ./examples/lyzr-agent -p "Summarize AI trends"
 
 # Just create (no prompt)
-gitagent lyzr run -r https://github.com/user/my-agent
+gapman lyzr run -r https://github.com/user/my-agent
 ```
 
 **Lyzr API Endpoints:**
@@ -878,7 +878,7 @@ GitHub Models API payload (OpenAI-compatible chat completions). Returns JSON wit
 
 ## Adapters & Runners
 
-When you run `gitagent run -a <adapter>`, the corresponding runner prepares the environment and launches the framework.
+When you run `gapman run -a <adapter>`, the corresponding runner prepares the environment and launches the framework.
 
 ### Claude Runner
 
@@ -1005,7 +1005,7 @@ Adapter: `github`
 
 ```bash
 export GITHUB_TOKEN="ghp_..."
-gitagent run -d ./my-agent -a github -p "Review this code"
+gapman run -d ./my-agent -a github -p "Review this code"
 ```
 
 ---
@@ -1032,10 +1032,10 @@ The git runner clones a repository and auto-detects the best adapter from the ag
 
 ```bash
 # Auto-detect and run
-gitagent run -a git -r https://github.com/user/my-agent -p "Hello"
+gapman run -a git -r https://github.com/user/my-agent -p "Hello"
 
 # Force a specific branch
-gitagent run -a git -r https://github.com/user/my-agent -b develop --refresh -p "Hello"
+gapman run -a git -r https://github.com/user/my-agent -b develop --refresh -p "Hello"
 ```
 
 ---
@@ -1157,7 +1157,7 @@ compliance/
 
 ### Audit Report
 
-Run `gitagent audit` to generate a section-by-section compliance checklist with pass/fail/warning indicators for every regulatory requirement.
+Run `gapman audit` to generate a section-by-section compliance checklist with pass/fail/warning indicators for every regulatory requirement.
 
 ---
 
@@ -1186,7 +1186,7 @@ dependencies:
       risk_assessment: low
 ```
 
-Run `gitagent install` to resolve and clone all dependencies.
+Run `gapman install` to resolve and clone all dependencies.
 
 ### Sub-Agents
 
@@ -1347,8 +1347,8 @@ examples/lyzr-agent/
 ```
 
 ```bash
-gitagent lyzr create -d ./examples/lyzr-agent
-gitagent lyzr run -d ./examples/lyzr-agent -p "What are AI agents?"
+gapman lyzr create -d ./examples/lyzr-agent
+gapman lyzr run -d ./examples/lyzr-agent -p "What are AI agents?"
 ```
 
 ---
@@ -1378,16 +1378,16 @@ gitagent/
 ├── src/
 │   ├── index.ts                    # CLI entry point (Commander)
 │   ├── commands/
-│   │   ├── init.ts                 # gitagent init
-│   │   ├── validate.ts             # gitagent validate
-│   │   ├── info.ts                 # gitagent info
-│   │   ├── export.ts               # gitagent export
-│   │   ├── import.ts               # gitagent import
-│   │   ├── install.ts              # gitagent install
-│   │   ├── audit.ts                # gitagent audit
-│   │   ├── skills.ts               # gitagent skills
-│   │   ├── run.ts                  # gitagent run
-│   │   └── lyzr.ts                 # gitagent lyzr
+│   │   ├── init.ts                 # gapman init
+│   │   ├── validate.ts             # gapman validate
+│   │   ├── info.ts                 # gapman info
+│   │   ├── export.ts               # gapman export
+│   │   ├── import.ts               # gapman import
+│   │   ├── install.ts              # gapman install
+│   │   ├── audit.ts                # gapman audit
+│   │   ├── skills.ts               # gapman skills
+│   │   ├── run.ts                  # gapman run
+│   │   └── lyzr.ts                 # gapman lyzr
 │   ├── adapters/
 │   │   ├── index.ts                # Re-exports all adapters
 │   │   ├── system-prompt.ts        # Markdown system prompt

--- a/docs/adapters/gemini.md
+++ b/docs/adapters/gemini.md
@@ -83,10 +83,10 @@ gemini --version
 
 ```bash
 # Export to stdout
-gitagent export --format gemini -d ./my-agent
+gapman export --format gemini -d ./my-agent
 
 # Save to file
-gitagent export --format gemini -d ./my-agent -o gemini-export.txt
+gapman export --format gemini -d ./my-agent -o gemini-export.txt
 
 # The export includes both GEMINI.md and .gemini/settings.json content
 ```
@@ -125,13 +125,13 @@ Agent description
 
 ```bash
 # Interactive mode
-gitagent run ./my-agent --adapter gemini
+gapman run ./my-agent --adapter gemini
 
 # Single-shot mode with prompt
-gitagent run ./my-agent --adapter gemini -p "Explain quantum computing"
+gapman run ./my-agent --adapter gemini -p "Explain quantum computing"
 
 # From git repository
-gitagent run --repo https://github.com/user/agent.git --adapter gemini
+gapman run --repo https://github.com/user/agent.git --adapter gemini
 ```
 
 **What Happens:**
@@ -145,11 +145,11 @@ gitagent run --repo https://github.com/user/agent.git --adapter gemini
 
 ```bash
 # Import from existing Gemini CLI project
-gitagent import --from gemini /path/to/gemini-project -d ./imported-agent
+gapman import --from gemini /path/to/gemini-project -d ./imported-agent
 
 # Verify the imported agent
 cd ./imported-agent
-gitagent validate
+gapman validate
 ```
 
 **What Gets Created:**
@@ -326,7 +326,7 @@ hooks:
 
 3. **Create proper tool schemas** - imported tools have minimal schemas
 
-4. **Test the agent** with `gitagent validate`
+4. **Test the agent** with `gapman validate`
 
 ### When Running
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -12,7 +12,7 @@ This document compares gitagent against three common alternatives developers rea
 |-----------|----------|----------------------|---------------|-------------------------------|
 | **Where does the agent live?** | Git repository = the agent | Separate spec file, usually checked into a repo | Config file(s) checked into a repo | Python/TypeScript class, checked into a repo |
 | **Portable across frameworks?** | ✅ Yes — `export` to 9+ targets | ⚠️ Depends on adoption | ❌ No — framework-specific parsers | ❌ No — tied to one framework |
-| **Runnable from repo URL?** | ✅ `gitagent run -r github.com/org/agent` | ❌ No | ❌ No | ❌ No |
+| **Runnable from repo URL?** | ✅ `gapman run -r github.com/org/agent` | ❌ No | ❌ No | ❌ No |
 | **Version-controlled identity** | ✅ Git tags = agent versions | ⚠️ Optional | ⚠️ Manual | ⚠️ Git blame only |
 | **Compliance / audit built-in** | ✅ Yes — FINRA, SEC, CFPB, SR 11-7 fields | ❌ No | ❌ No | ❌ No |
 | **Multi-agent topology** | ✅ Native `agents:` block + SOD | ❌ No standard | ❌ No | ⚠️ Framework-specific |
@@ -51,8 +51,8 @@ Many teams define agents with hand-rolled YAML files that are parsed by custom c
 **Raw YAML/JSON** gives you full flexibility but zero standardization. Every team invents their own schema, every framework reads it differently, and there is no tooling layer.
 
 **gitagent** gives you a *community standard* schema with:
-- A validated `agent.yaml` spec (run `gitagent validate` to check conformance)
-- A CLI layer (`gitagent export`, `gitagent run`, `gitagent audit`) that acts on the standard
+- A validated `agent.yaml` spec (run `gapman validate` to check conformance)
+- A CLI layer (`gapman export`, `gapman run`, `gapman audit`) that acts on the standard
 - Installable skills from a shared ecosystem (`npx skills add`)
 - A compliance block that maps to real regulatory frameworks (FINRA 3110/4511, SEC 17a-4, SR 11-7, CFPB) — not invented fields
 
@@ -65,11 +65,11 @@ Many teams define agents with hand-rolled YAML files that are parsed by custom c
 
 Raw YAML → gitagent is straightforward:
 ```bash
-gitagent init -t minimal  # scaffold the standard layout
+gapman init -t minimal  # scaffold the standard layout
 # copy your system prompt → SOUL.md
 # copy your rules → RULES.md
 # move your config fields into agent.yaml
-gitagent validate         # check conformance
+gapman validate         # check conformance
 ```
 
 ---
@@ -88,11 +88,11 @@ LangChain agents, CrewAI agents, AutoGen agents, etc. are all defined as Python 
 **gitagent** sits *above* frameworks. You define the agent once in the standard format, then export to the framework of your choice:
 
 ```bash
-gitagent export -f crewai    # → YAML config for CrewAI
-gitagent export -f openai    # → Python script for OpenAI Agents SDK
-gitagent export -f langchain # → Python script for LangChain
-gitagent export -f langgraph # → Python StateGraph for LangGraph
-gitagent export -f claude-code  # → CLAUDE.md for Claude Code
+gapman export -f crewai    # → YAML config for CrewAI
+gapman export -f openai    # → Python script for OpenAI Agents SDK
+gapman export -f langchain # → Python script for LangChain
+gapman export -f langgraph # → Python StateGraph for LangGraph
+gapman export -f claude-code  # → CLAUDE.md for Claude Code
 ```
 
 The framework-native implementation becomes a *derived artifact* of the canonical gitagent definition, not the source of truth.
@@ -104,7 +104,7 @@ The framework-native implementation becomes a *derived artifact* of the canonica
 
 ### The hybrid pattern
 
-Many teams combine both: gitagent defines the agent’s identity, compliance, and skills; framework-native code handles tool implementations, memory backends, and custom orchestration. The `gitagent export` output is a starting point, not a locked output.
+Many teams combine both: gitagent defines the agent’s identity, compliance, and skills; framework-native code handles tool implementations, memory backends, and custom orchestration. The `gapman export` output is a starting point, not a locked output.
 
 ---
 
@@ -135,7 +135,7 @@ compliance:
       - [maker, checker]  # No agent may both make and check its own work
 ```
 
-Running `gitagent audit` against this produces a structured compliance report. No other agent definition format offers this.
+Running `gapman audit` against this produces a structured compliance report. No other agent definition format offers this.
 
 For teams building agents in regulated industries — financial services, healthcare (HIPAA), or any environment governed by SEC/FINRA/CFPB/MiCA rules — gitagent’s compliance model is the primary differentiator.
 

--- a/examples/gitagent-helper/README.md
+++ b/examples/gitagent-helper/README.md
@@ -6,10 +6,10 @@ The official gitagent assistant — an AI agent that helps you build, run, and m
 
 ```bash
 # Run directly from GitHub
-gitagent run -r https://github.com/anthropics/gitagent-helper
+gapman run -r https://github.com/anthropics/gitagent-helper
 
 # Or with a prompt
-gitagent run -r https://github.com/anthropics/gitagent-helper -p "How do I create my first agent?"
+gapman run -r https://github.com/anthropics/gitagent-helper -p "How do I create my first agent?"
 ```
 
 ## What It Can Do
@@ -34,7 +34,7 @@ gitagent run -r https://github.com/anthropics/gitagent-helper -p "How do I creat
 
 ```bash
 git clone https://github.com/anthropics/gitagent-helper
-gitagent run -d ./gitagent-helper
+gapman run -d ./gitagent-helper
 ```
 
 ## Structure

--- a/examples/gitagent-helper/RULES.md
+++ b/examples/gitagent-helper/RULES.md
@@ -5,7 +5,7 @@
 - Show the expected output or result of a command
 - Use real, working examples — not pseudocode
 - Mention required environment variables before showing adapter commands
-- Suggest `gitagent validate` after any agent.yaml changes
+- Suggest `gapman validate` after any agent.yaml changes
 
 ## Must Never
 - Make up CLI flags that don't exist

--- a/examples/gitagent-helper/knowledge/command-reference.md
+++ b/examples/gitagent-helper/knowledge/command-reference.md
@@ -4,22 +4,22 @@
 
 | Command | Description |
 |---------|-------------|
-| `gitagent init` | Scaffold a new agent repo (`-t minimal\|standard\|full`) |
-| `gitagent validate` | Validate agent.yaml and structure (`-c` for compliance) |
-| `gitagent info` | Show agent summary |
-| `gitagent export` | Export to other formats (`-f system-prompt\|claude-code\|openai\|crewai\|openclaw\|nanobot\|lyzr\|github`) |
-| `gitagent import` | Import from other frameworks (`--from claude\|cursor\|crewai`) |
-| `gitagent install` | Resolve git dependencies |
-| `gitagent audit` | Generate compliance audit report |
-| `gitagent skills search` | Search skill registries |
-| `gitagent skills install` | Install a skill |
-| `gitagent skills list` | List discovered skills |
-| `gitagent skills info` | Inspect a skill |
-| `gitagent run` | Run agent with an adapter (`-a claude\|openai\|crewai\|openclaw\|nanobot\|lyzr\|github\|git\|prompt`) |
-| `gitagent lyzr create` | Create agent on Lyzr Studio |
-| `gitagent lyzr update` | Push changes to Lyzr |
-| `gitagent lyzr info` | Show linked Lyzr agent ID |
-| `gitagent lyzr run` | Clone + create + chat on Lyzr in one command |
+| `gapman init` | Scaffold a new agent repo (`-t minimal\|standard\|full`) |
+| `gapman validate` | Validate agent.yaml and structure (`-c` for compliance) |
+| `gapman info` | Show agent summary |
+| `gapman export` | Export to other formats (`-f system-prompt\|claude-code\|openai\|crewai\|openclaw\|nanobot\|lyzr\|github`) |
+| `gapman import` | Import from other frameworks (`--from claude\|cursor\|crewai`) |
+| `gapman install` | Resolve git dependencies |
+| `gapman audit` | Generate compliance audit report |
+| `gapman skills search` | Search skill registries |
+| `gapman skills install` | Install a skill |
+| `gapman skills list` | List discovered skills |
+| `gapman skills info` | Inspect a skill |
+| `gapman run` | Run agent with an adapter (`-a claude\|openai\|crewai\|openclaw\|nanobot\|lyzr\|github\|git\|prompt`) |
+| `gapman lyzr create` | Create agent on Lyzr Studio |
+| `gapman lyzr update` | Push changes to Lyzr |
+| `gapman lyzr info` | Show linked Lyzr agent ID |
+| `gapman lyzr run` | Clone + create + chat on Lyzr in one command |
 
 ## Common Flags
 

--- a/examples/gitagent-helper/skills/create-agent/SKILL.md
+++ b/examples/gitagent-helper/skills/create-agent/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 2. Write `agent.yaml` with required fields (see below)
 3. Create `SOUL.md` with agent identity
 4. Add skills, tools, and knowledge as needed
-5. Validate: `gitagent validate -d ./my-agent`
+5. Validate: `gapman validate -d ./my-agent`
 
 ## agent.yaml Reference
 

--- a/examples/gitagent-helper/skills/export-agent/SKILL.md
+++ b/examples/gitagent-helper/skills/export-agent/SKILL.md
@@ -16,7 +16,7 @@ After exporting, check the output matches expectations:
 
 ```bash
 # Verify export file was created and contains agent name
-gitagent export -f system-prompt -d ./my-agent | head -5
+gapman export -f system-prompt -d ./my-agent | head -5
 ```
 
 ## Export
@@ -24,7 +24,7 @@ gitagent export -f system-prompt -d ./my-agent | head -5
 Convert a gitagent definition to another framework:
 
 ```bash
-gitagent export -f <format> -d ./my-agent [-o output-file]
+gapman export -f <format> -d ./my-agent [-o output-file]
 ```
 
 ### Formats
@@ -44,19 +44,19 @@ gitagent export -f <format> -d ./my-agent [-o output-file]
 
 ```bash
 # Get a system prompt for any LLM
-gitagent export -f system-prompt -d ./my-agent
+gapman export -f system-prompt -d ./my-agent
 
 # Generate a CLAUDE.md
-gitagent export -f claude-code -d ./my-agent -o CLAUDE.md
+gapman export -f claude-code -d ./my-agent -o CLAUDE.md
 
 # Generate Python code for OpenAI
-gitagent export -f openai -d ./my-agent -o agent.py
+gapman export -f openai -d ./my-agent -o agent.py
 
 # Preview what Lyzr API will receive
-gitagent export -f lyzr -d ./my-agent
+gapman export -f lyzr -d ./my-agent
 
 # Preview GitHub Models payload
-gitagent export -f github -d ./my-agent
+gapman export -f github -d ./my-agent
 ```
 
 ## Import
@@ -64,7 +64,7 @@ gitagent export -f github -d ./my-agent
 Convert existing agent frameworks into gitagent:
 
 ```bash
-gitagent import --from <format> <path> [-d target-dir]
+gapman import --from <format> <path> [-d target-dir]
 ```
 
 ### Sources
@@ -79,11 +79,11 @@ gitagent import --from <format> <path> [-d target-dir]
 
 ```bash
 # Import a Claude Code project
-gitagent import --from claude ./my-project
+gapman import --from claude ./my-project
 
 # Import from Cursor
-gitagent import --from cursor ./.cursorrules
+gapman import --from cursor ./.cursorrules
 
 # Import CrewAI config
-gitagent import --from crewai ./crew.yaml -d ./imported
+gapman import --from crewai ./crew.yaml -d ./imported
 ```

--- a/examples/gitagent-helper/skills/get-started/SKILL.md
+++ b/examples/gitagent-helper/skills/get-started/SKILL.md
@@ -27,32 +27,32 @@ Walk the user through these steps:
 1. **Scaffold** — Pick a template:
    ```bash
    # Minimal (2 files)
-   gitagent init --template minimal --dir ./my-agent
+   gapman init --template minimal --dir ./my-agent
 
    # Standard (with skills, tools, knowledge)
-   gitagent init --template standard --dir ./my-agent
+   gapman init --template standard --dir ./my-agent
 
    # Full (compliance, hooks, memory, workflows)
-   gitagent init --template full --dir ./my-agent
+   gapman init --template full --dir ./my-agent
    ```
 
 2. **Edit** — Customize `agent.yaml` (name, description, model) and `SOUL.md` (identity, personality)
 
 3. **Validate** — Check your work:
    ```bash
-   gitagent validate -d ./my-agent
+   gapman validate -d ./my-agent
    ```
 
 4. **Run** — Launch with Claude:
    ```bash
-   gitagent run -d ./my-agent
+   gapman run -d ./my-agent
    ```
 
 5. **Share** — Push to git and anyone can run it:
    ```bash
    cd my-agent && git init && git add . && git commit -m "Initial agent"
    # Push to GitHub, then:
-   gitagent run -r https://github.com/you/my-agent
+   gapman run -r https://github.com/you/my-agent
    ```
 
 ### Minimum Required Files

--- a/examples/gitagent-helper/skills/manage-skills/SKILL.md
+++ b/examples/gitagent-helper/skills/manage-skills/SKILL.md
@@ -18,49 +18,49 @@ When a user wants to find skills, install them, create new ones, or understand t
 After installing a skill, confirm it's available:
 
 ```bash
-gitagent skills list -d ./my-agent | grep "code-review"
+gapman skills list -d ./my-agent | grep "code-review"
 ```
 
 ## Search Skills
 
 ```bash
 # Search SkillsMP registry
-gitagent skills search "code review"
+gapman skills search "code review"
 
 # Search GitHub
-gitagent skills search "pdf reader" --provider github
+gapman skills search "pdf reader" --provider github
 
 # Limit results
-gitagent skills search "testing" --limit 5
+gapman skills search "testing" --limit 5
 ```
 
 ## Install Skills
 
 ```bash
 # Install from SkillsMP to agent-local skills/
-gitagent skills install code-review -d ./my-agent
+gapman skills install code-review -d ./my-agent
 
 # Install globally to ~/.agents/skills/
-gitagent skills install code-review --global
+gapman skills install code-review --global
 
 # Install from GitHub
-gitagent skills install owner/repo#skills/my-skill --provider github
+gapman skills install owner/repo#skills/my-skill --provider github
 ```
 
 ## List Skills
 
 ```bash
 # Show all discovered skills (local + global)
-gitagent skills list -d ./my-agent
+gapman skills list -d ./my-agent
 
 # Only agent-local skills
-gitagent skills list -d ./my-agent --local
+gapman skills list -d ./my-agent --local
 ```
 
 ## Inspect a Skill
 
 ```bash
-gitagent skills info code-review -d ./my-agent
+gapman skills info code-review -d ./my-agent
 ```
 
 Shows: name, description, license, allowed tools, metadata, optional directories.
@@ -96,7 +96,7 @@ skills:
 
 4. Validate:
 ```bash
-gitagent validate -d ./my-agent
+gapman validate -d ./my-agent
 ```
 
 ## Skill Discovery Paths

--- a/examples/gitagent-helper/skills/run-agent/SKILL.md
+++ b/examples/gitagent-helper/skills/run-agent/SKILL.md
@@ -25,13 +25,13 @@ If you see authentication errors:
 
 ```bash
 # Run local agent with Claude (default)
-gitagent run -d ./my-agent
+gapman run -d ./my-agent
 
 # Run from git repo
-gitagent run -r https://github.com/user/agent
+gapman run -r https://github.com/user/agent
 
 # Run with a prompt (one-shot mode)
-gitagent run -d ./my-agent -p "Review my code"
+gapman run -d ./my-agent -p "Review my code"
 ```
 
 ## Adapters
@@ -52,24 +52,24 @@ gitagent run -d ./my-agent -p "Review my code"
 
 ```bash
 # Claude (interactive)
-gitagent run -d ./my-agent
+gapman run -d ./my-agent
 
 # GitHub Models (one-shot, streaming)
 export GITHUB_TOKEN="ghp_..."
-gitagent run -d ./my-agent -a github -p "Explain this codebase"
+gapman run -d ./my-agent -a github -p "Explain this codebase"
 
 # Lyzr (creates agent on Lyzr Studio + chats)
 export LYZR_API_KEY="..."
-gitagent run -r https://github.com/user/agent -a lyzr -p "Hello"
+gapman run -r https://github.com/user/agent -a lyzr -p "Hello"
 
 # Lyzr one-liner (clone + create + chat)
-gitagent lyzr run -r https://github.com/user/agent -p "Hello"
+gapman lyzr run -r https://github.com/user/agent -p "Hello"
 
 # Auto-detect adapter from repo
-gitagent run -r https://github.com/user/agent -a git -p "Hello"
+gapman run -r https://github.com/user/agent -a git -p "Hello"
 
 # Just print the system prompt
-gitagent run -d ./my-agent -a prompt
+gapman run -d ./my-agent -a prompt
 ```
 
 ## Git Caching
@@ -77,13 +77,13 @@ gitagent run -d ./my-agent -a prompt
 Repos cloned via `-r` are cached at `~/.gitagent/cache/`:
 ```bash
 # Use cache (default)
-gitagent run -r https://github.com/user/agent
+gapman run -r https://github.com/user/agent
 
 # Force refresh
-gitagent run -r https://github.com/user/agent --refresh
+gapman run -r https://github.com/user/agent --refresh
 
 # No cache (temp dir, deleted after)
-gitagent run -r https://github.com/user/agent --no-cache
+gapman run -r https://github.com/user/agent --no-cache
 ```
 
 ## Auto-Detection (`-a git`)

--- a/examples/jason-my-claw-is-the-law-deebee-4567b4/README.md
+++ b/examples/jason-my-claw-is-the-law-deebee-4567b4/README.md
@@ -55,10 +55,10 @@ jason-my-claw-is-the-law-deebee-4567b4/
 
 ```bash
 # Install gitagent
-npm install -g @shreyaskapale/gitagent
+npm install -g @open-gitagent/gapman
 
 # Clone this agent
-gitagent clone open-gitagent/gitagent examples/jason-my-claw-is-the-law-deebee-4567b4 my-jason
+gapman clone open-gitagent/gitagent examples/jason-my-claw-is-the-law-deebee-4567b4 my-jason
 
 # Review the rules before running
 cat my-jason/RULES.md

--- a/examples/lyzr-agent/README.md
+++ b/examples/lyzr-agent/README.md
@@ -6,13 +6,13 @@ A gitagent example designed to run on [Lyzr Studio](https://studio.lyzr.ai).
 
 ```bash
 # Create the agent on Lyzr
-gitagent lyzr create -d ./examples/lyzr-agent
+gapman lyzr create -d ./examples/lyzr-agent
 
 # Chat with it
-gitagent lyzr run -d ./examples/lyzr-agent -p "Summarize the latest trends in AI agents"
+gapman lyzr run -d ./examples/lyzr-agent -p "Summarize the latest trends in AI agents"
 
 # Or do it all in one command from a git repo
-gitagent lyzr run -r https://github.com/youruser/lyzr-research-agent -p "What is RAG?"
+gapman lyzr run -r https://github.com/youruser/lyzr-research-agent -p "What is RAG?"
 ```
 
 ## Prerequisites
@@ -29,11 +29,11 @@ Get your API key from [Lyzr Studio](https://studio.lyzr.ai).
 
 | Command | Description |
 |---------|-------------|
-| `gitagent lyzr create -d .` | Create the agent on Lyzr Studio |
-| `gitagent lyzr update -d .` | Push local changes to Lyzr |
-| `gitagent lyzr info -d .` | Show the linked Lyzr agent ID |
-| `gitagent lyzr run -d . -p "..."` | Chat with the agent |
-| `gitagent export -d . -f lyzr` | Preview the Lyzr API payload |
+| `gapman lyzr create -d .` | Create the agent on Lyzr Studio |
+| `gapman lyzr update -d .` | Push local changes to Lyzr |
+| `gapman lyzr info -d .` | Show the linked Lyzr agent ID |
+| `gapman lyzr run -d . -p "..."` | Chat with the agent |
+| `gapman export -d . -f lyzr` | Preview the Lyzr API payload |
 
 ## How It Works
 
@@ -44,4 +44,4 @@ Get your API key from [Lyzr Studio](https://studio.lyzr.ai).
 5. `skills/research/SKILL.md` provides structured research instructions
 6. `.gitagent_adapter` tells the git runner to use Lyzr automatically
 
-When you run `gitagent lyzr create`, all of these files are combined into a single Lyzr API payload and sent to Lyzr Studio. The returned agent ID is saved to `.lyzr_agent_id` for subsequent runs.
+When you run `gapman lyzr create`, all of these files are combined into a single Lyzr API payload and sent to Lyzr Studio. The returned agent ID is saved to `.lyzr_agent_id` for subsequent runs.

--- a/examples/nvidia-deep-researcher/README.md
+++ b/examples/nvidia-deep-researcher/README.md
@@ -21,7 +21,7 @@ This gitagent definition faithfully translates the NVIDIA Jinja2 prompts (`orche
 | **SOD enforcement** | Implicit in code | Explicit roles, conflicts, and handoffs validated in CI |
 | **Fork & customize** | Modify Python code | Fork for legal/medical/finance variants without touching code |
 | **Memory** | No persistence across sessions | Version-controlled research session history |
-| **CI/CD** | Manual testing | `gitagent validate --compliance` on every push |
+| **CI/CD** | Manual testing | `gapman validate --compliance` on every push |
 | **Audit trail** | None | Every prompt, skill, and rule change traced via git |
 
 ## Quick Start
@@ -30,23 +30,23 @@ This gitagent definition faithfully translates the NVIDIA Jinja2 prompts (`orche
 
 ```bash
 cd examples/nvidia-deep-researcher
-gitagent validate --compliance
+gapman validate --compliance
 ```
 
 ### Export
 
 ```bash
 # System prompt (for any LLM)
-gitagent export --format system-prompt
+gapman export --format system-prompt
 
 # Claude Code (generates CLAUDE.md)
-gitagent export --format claude-code
+gapman export --format claude-code
 ```
 
 ### Info
 
 ```bash
-gitagent info
+gapman info
 ```
 
 ## Structure
@@ -88,7 +88,7 @@ cd my-legal-researcher
 # Add legal knowledge docs to knowledge/
 # Update agent.yaml with domain-specific metadata
 
-gitagent validate --compliance
+gapman validate --compliance
 ```
 
 No Python code changes needed — just edit the markdown and YAML files.

--- a/examples/standard/memory/daily-log/2026-02-18.md
+++ b/examples/standard/memory/daily-log/2026-02-18.md
@@ -1,7 +1,7 @@
 # 2026-02-18
 
 ## Session Summary
-Implemented `gitagent run` command with git caching and multi-adapter support.
+Implemented `gapman run` command with git caching and multi-adapter support.
 
 ## What Happened
 - Created `src/utils/git-cache.ts` — shallow clone with SHA-based cache at `~/.gitagent/cache/`

--- a/spec/SPECIFICATION.md
+++ b/spec/SPECIFICATION.md
@@ -438,7 +438,7 @@ Provides fallback instructions compatible with Cursor, Copilot, and other tools 
 
 ## 7. Skills — Agent Skills Open Standard
 
-gitagent fully adopts the **Agent Skills** open standard ([agentskills.io](https://agentskills.io)) for its `skills/` directory. Any valid Agent Skills skill works in gitagent with zero modification, and gitagent skills work in Claude Code, Codex, VS Code, Cursor, Gemini CLI, and all other tools that support the standard.
+gitagent fully adopts the **Agent Skills** open standard ([agentskills.io](https://agentskills.io)) for its `skills/` directory. Any valid Agent Skills skill works in gitagent with zero modification, and gapman skills work in Claude Code, Codex, VS Code, Cursor, Gemini CLI, and all other tools that support the standard.
 
 ### SKILL.md Format (Agent Skills Standard)
 
@@ -539,10 +539,10 @@ Built-in providers:
 
 | Command | Description |
 |---------|-------------|
-| `gitagent skills search <query>` | Search for skills in a registry |
-| `gitagent skills install <name>` | Install a skill from a registry |
-| `gitagent skills list` | List discovered skills |
-| `gitagent skills info <name>` | Show detailed skill information |
+| `gapman skills search <query>` | Search for skills in a registry |
+| `gapman skills install <name>` | Install a skill from a registry |
+| `gapman skills list` | List discovered skills |
+| `gapman skills info <name>` | Show detailed skill information |
 
 Options: `--provider <name>`, `--global` (install to `~/.agents/skills/`), `--dir <dir>`
 
@@ -945,28 +945,28 @@ A valid gitagent repository must:
 
 | Command | Description |
 |---------|-------------|
-| `gitagent init [--template]` | Scaffold new agent (`minimal`, `standard`, `full`) |
-| `gitagent validate [--compliance]` | Validate against spec, optionally with regulatory checks |
-| `gitagent info` | Display agent summary |
-| `gitagent export --format <fmt>` | Export (`system-prompt`, `claude-code`, `openai`, `crewai`) |
-| `gitagent import --from <fmt> <path>` | Import (`claude`, `cursor`, `crewai`) |
-| `gitagent install` | Resolve and install git-based dependencies |
-| `gitagent audit` | Generate compliance audit report |
-| `gitagent skills search <query>` | Search for skills in a registry |
-| `gitagent skills install <name>` | Install a skill from a registry |
-| `gitagent skills list` | List discovered skills |
-| `gitagent skills info <name>` | Show detailed skill information |
+| `gapman init [--template]` | Scaffold new agent (`minimal`, `standard`, `full`) |
+| `gapman validate [--compliance]` | Validate against spec, optionally with regulatory checks |
+| `gapman info` | Display agent summary |
+| `gapman export --format <fmt>` | Export (`system-prompt`, `claude-code`, `openai`, `crewai`) |
+| `gapman import --from <fmt> <path>` | Import (`claude`, `cursor`, `crewai`) |
+| `gapman install` | Resolve and install git-based dependencies |
+| `gapman audit` | Generate compliance audit report |
+| `gapman skills search <query>` | Search for skills in a registry |
+| `gapman skills install <name>` | Install a skill from a registry |
+| `gapman skills list` | List discovered skills |
+| `gapman skills info <name>` | Show detailed skill information |
 
 ### Planned (future versions)
 
 | Command | Description |
 |---------|-------------|
-| `gitagent run [--env] [--model]` | Start agent interactively |
+| `gapman run [--env] [--model]` | Start agent interactively |
 | `gitagent serve --protocol <proto>` | Run as A2A/MCP server |
-| `gitagent test` | Run against example scenarios |
+| `gapman test` | Run against example scenarios |
 | `gitagent publish` | Publish to registry |
 | `gitagent card` | Generate A2A Agent Card |
-| `gitagent diff <ref1> <ref2>` | Semantic diff between versions |
+| `gapman diff <ref1> <ref2>` | Semantic diff between versions |
 
 ## 19a. JSON Schemas
 


### PR DESCRIPTION
## Summary

The CLI binary was renamed `gitagent` → `gapman` in v0.3.0, with `gitagent` kept as an alias for backward compatibility. The docs were never fully swept to match. This PR updates all command-line examples to use the canonical `gapman` invocation.

## What changed

- **218 occurrences across 19 files** rewritten via a regex sweep
- `gitagent <verb>` → `gapman <verb>` for all 14 CLI verbs (init, validate, info, export, import, install, audit, skills, run, lyzr, registry, test, diff, clone)
- `gitagent --flag` → `gapman --flag`
- `npx gitagent` → `npx gapman`
- `@shreyaskapale/gitagent` (deprecated) and `@open-gitagent/gitagent` (renamed) → `@open-gitagent/gapman`
- `npm install -g gitagent` (unscoped) → `npm install -g gapman`

## What deliberately did NOT change

- "gitagent" as the project / protocol name in prose (e.g., "gitagent vs. Alternatives", "the gitagent standard")
- `open-gitagent/gitagent-protocol` repo URL
- `.gitagent/` runtime state directory
- `gitagent` as a class/identifier in source code (unchanged)
- `paper/open-gap.md` (paper has its own canonical phrasing)
- The two backward-compat alias notes (`README.md:256` and `docs.md:62`) explicitly mention that `gitagent` is installed as an alias — those stay

## Files changed

- `README.md`, `docs.md`, `CONTRIBUTING.md`
- `spec/SPECIFICATION.md`
- `docs/comparison.md`, `docs/adapters/gemini.md`
- `examples/gitagent-helper/` (8 files), `examples/lyzr-agent/`, `examples/nvidia-deep-researcher/`, `examples/jason-my-claw-is-the-law-deebee-4567b4/`, `examples/standard/memory/daily-log/2026-02-18.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`

## Test plan

- [ ] `git diff main` shows pure docs changes — no source code touched
- [ ] No remaining `gitagent <verb>` CLI invocations in tracked docs (verified via `grep -r 'gitagent (init|validate|...) ' --include='*.md'`)
- [ ] Backward-compat alias notes preserved in README and docs.md