### PR TITLE
fix: add financial_governance to ComplianceConfig type (unblocks build/release)

### DIFF
--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -141,6 +141,22 @@ export interface ComplianceConfig {
     }>;
     enforcement?: string;
   };
+  financial_governance?: {
+    enabled?: boolean;
+    firewall?: string;
+    spending?: {
+      max_per_transaction_cents: number;
+      max_monthly_cents?: number;
+      currency?: string;
+      allowed_categories?: string[];
+      blocked_categories?: string[];
+    };
+    approval?: {
+      require_above_cents?: number;
+      timeout_minutes?: number;
+      auto_deny_on_timeout?: boolean;
+    };
+  };
 }
 
 export function loadAgentManifest(dir: string): AgentManifest {


### PR DESCRIPTION
## Problem

The v0.4.0 release workflow failed at `npm run build` with:

```
src/adapters/shared.ts(67,9): error TS2339: Property 'financial_governance' does not exist on type 'ComplianceConfig'.
src/adapters/shared.ts(68,18): error TS2339: ...
src/commands/validate.ts(374,16): error TS2339: ...
```

PR #79 (financial_governance Phase 1) added the JSON schema + field *usage* in `shared.ts` and `validate.ts`, but never added `financial_governance` to the `ComplianceConfig` TypeScript interface in `src/utils/loader.ts`. `main` has been failing to compile since that merge.

## Fix

Adds the `financial_governance` shape to `ComplianceConfig`, matching every field access in the two consumers:
- `enabled?`, `firewall?`
- `spending?` → `max_per_transaction_cents` (required `number` so `validate.ts`'s `<= 0` compiles under `strict`), `max_monthly_cents?`, `currency?`, `allowed_categories?`, `blocked_categories?`
- `approval?` → `require_above_cents?`, `timeout_minutes?`, `auto_deny_on_timeout?`

## Test plan

- [ ] `npm run build` compiles (the CI workflow will confirm)
- [ ] Re-run v0.4.0 release after merge → publish succeeds