### PR TITLE
fix: repository.url → open-gitagent/opengap (unblocks provenance publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-gitagent/gitagent.git"
+    "url": "git+https://github.com/open-gitagent/opengap.git"
   },
   "homepage": "https://gitagent.sh",
   "bugs": {
-    "url": "https://github.com/open-gitagent/gitagent/issues"
+    "url": "https://github.com/open-gitagent/opengap/issues"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Problem

`npm publish --provenance` failed with:

```
npm error 422 Unprocessable Entity — Error verifying sigstore provenance bundle:
repository.url is "git+https://github.com/open-gitagent/gitagent.git",
expected to match "https://github.com/open-gitagent/opengap" from provenance
```

The repo was renamed to `opengap` but `package.json` still pointed `repository.url` and `bugs.url` at the original `open-gitagent/gitagent`. Provenance attestation requires the URL to match the building repo.

## Fix
- `repository.url` → `git+https://github.com/open-gitagent/opengap.git` (the `git+` prefix also silences npm's auto-correction warning)
- `bugs.url` → `https://github.com/open-gitagent/opengap/issues`

## Test plan
- [ ] Re-run v0.4.0 release → provenance publish succeeds for scoped + unscoped