### PR TITLE
ci: publish scoped @open-gitagent/opengap only (drop blocked unscoped step)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,9 +28,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish opengap (unscoped alias)
-        run: |
-          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.name='opengap';fs.writeFileSync('package.json',JSON.stringify(p,null,2));"
-          npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Note: the unscoped root name "opengap" cannot be published — npm rejects
+      # it as too similar to the existing "openai" package (typosquatting guard,
+      # E403). The package is published under the scoped name only.


### PR DESCRIPTION
## Why

The unscoped root name `opengap` cannot be published — npm returns `403 Forbidden`: "Package name too similar to existing package **openai**" (their typosquatting guard). The scoped `@open-gitagent/opengap` publishes fine.

## Change
Removes the unscoped publish step from `publish.yml`. Releases now publish only the scoped package, so the workflow stops reporting failure. Left an inline comment documenting why.

`@open-gitagent/opengap@0.4.0` is already live on npm.